### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   lint-and-format:
     name: Lint and Format Check
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/kiakiraki/metamark/security/code-scanning/1](https://github.com/kiakiraki/metamark/security/code-scanning/1)

To address the flagged issue, we must add a `permissions` block to the affected job or at the workflow level. Since only the `lint-and-format` job is defined (and it is the only job in this workflow), adding `permissions: contents: read` at either the root or within the job will suffice. The best practice is to add the permissions at the job level if different jobs are likely to have different requirements, or at the workflow level if all jobs share the same needs. Here, adding under `lint-and-format:` is clearest.  
**Steps:**  
- Edit `.github/workflows/ci.yml`.
- Under `lint-and-format:` (after line 11), insert a new key:
  ```yaml
  permissions:
    contents: read
  ```
No additional imports, definitions, or packages are needed. Only this block must be added.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
