### PR TITLE
feat(template): add Film style with dot-matrix date imprint

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/next/no-page-custom-font */
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
@@ -25,6 +26,19 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        {/* Dot-matrix style font for Film template */}
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin=""
+        />
+        <link
+          href="https://fonts.googleapis.com/css2?family=DotGothic16&display=swap"
+          rel="stylesheet"
+        />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/src/services/canvasRenderer.ts
+++ b/src/services/canvasRenderer.ts
@@ -140,22 +140,34 @@ export class CanvasRenderer {
       ? drawRect!.drawY + drawRect!.drawHeight
       : canvasHeight;
 
+    const isFilm = template.id === 'film';
+    const extraInset = isFilm ? margin : 0; // nudge inward for Film
+
     switch (overlayPosition) {
       case 'top-left':
         x = (hasDrawRect ? imageLeft : 0) + margin;
         y = (hasDrawRect ? imageTop : 0) + margin;
         break;
       case 'top-right':
-        x = (hasDrawRect ? imageRight : canvasWidth) - scaledWidth - margin;
-        y = (hasDrawRect ? imageTop : 0) + margin;
+        x =
+          (hasDrawRect ? imageRight : canvasWidth) -
+          scaledWidth -
+          (margin + extraInset);
+        y = (hasDrawRect ? imageTop : 0) + (margin + extraInset);
         break;
       case 'bottom-left':
         x = (hasDrawRect ? imageLeft : 0) + margin;
         y = (hasDrawRect ? imageBottom : canvasHeight) - scaledHeight - margin;
         break;
       case 'bottom-right':
-        x = (hasDrawRect ? imageRight : canvasWidth) - scaledWidth - margin;
-        y = (hasDrawRect ? imageBottom : canvasHeight) - scaledHeight - margin;
+        x =
+          (hasDrawRect ? imageRight : canvasWidth) -
+          scaledWidth -
+          (margin + extraInset);
+        y =
+          (hasDrawRect ? imageBottom : canvasHeight) -
+          scaledHeight -
+          (margin + extraInset);
         break;
       default:
         x = template.position.x;
@@ -362,16 +374,19 @@ export class CanvasRenderer {
 
       ctx.save();
       ctx.translate(anchorX, anchorY);
-      ctx.rotate(isTop ? Math.PI / 2 : -Math.PI / 2);
+      // Reverse rotation direction per feedback
+      ctx.rotate(isTop ? -Math.PI / 2 : Math.PI / 2);
       const prevAlign = ctx.textAlign;
       const prevBaseline = ctx.textBaseline;
-      ctx.textAlign = 'left';
+      // Anchor to the edge and draw inward to avoid clipping
+      ctx.textAlign = 'right';
       ctx.textBaseline = 'top';
 
       // Render lines along the long edge
       let offset = 0;
       for (const line of allTextLines) {
-        ctx.fillText(line, isTop ? offset : -offset, 0);
+        // With right alignment, x is the right edge of the text in rotated coordinates
+        ctx.fillText(line, isTop ? -offset : offset, 0);
         offset += lineHeight;
       }
 

--- a/src/services/canvasRenderer.ts
+++ b/src/services/canvasRenderer.ts
@@ -51,17 +51,46 @@ export class CanvasRenderer {
     // Calculate scale factor based on canvas size
     const scaleFactor = Math.min(settings.width, settings.height) / 1000; // Base scale for 1000px
 
+    // Ensure Film font is loaded before drawing overlay
+    if (template.id === 'film') {
+      try {
+        const fontSize = Math.max(12, template.style.fontSize * scaleFactor);
+        // Attempt to load DotGothic16; ignore if not supported
+        // @ts-expect-error: document.fonts may not exist in all environments
+        if (document && document.fonts && document.fonts.load) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          await (document as any).fonts.load(`${fontSize}px DotGothic16`);
+        }
+      } catch {
+        // noop
+      }
+    }
+
     // Calculate dynamic position based on overlay position setting and exif data
+    // For Film style, fix overlay position: landscape -> bottom-right, portrait -> top-right
+    const isPortraitImage = image.height > image.width;
+    const effectiveSettings: CanvasSettings =
+      template.id === 'film'
+        ? {
+            ...settings,
+            overlayPosition: isPortraitImage ? 'top-right' : 'bottom-right',
+          }
+        : settings;
+
     const dynamicTemplate = this.calculateDynamicPosition(
       template,
-      settings,
+      effectiveSettings,
       settings.width,
       settings.height,
-      exifData
+      exifData,
+      { drawX, drawY, drawWidth, drawHeight }
     );
 
     // Draw template overlay with scaling
-    this.drawTemplate(ctx, dynamicTemplate, exifData, scaleFactor);
+    this.drawTemplate(ctx, dynamicTemplate, exifData, scaleFactor, {
+      imageIsPortrait: isPortraitImage,
+      overlayPosition: effectiveSettings.overlayPosition,
+    });
 
     // Return as data URL
     return canvas.toDataURL(
@@ -75,7 +104,13 @@ export class CanvasRenderer {
     settings: CanvasSettings,
     canvasWidth: number,
     canvasHeight: number,
-    exifData: NormalizedExifData
+    exifData: NormalizedExifData,
+    drawRect?: {
+      drawX: number;
+      drawY: number;
+      drawWidth: number;
+      drawHeight: number;
+    }
   ): Template {
     const { overlayPosition } = settings;
 
@@ -94,22 +129,33 @@ export class CanvasRenderer {
 
     let x: number, y: number;
 
+    // If we know where the image was drawn, align overlay to the image bounds
+    const hasDrawRect = !!drawRect;
+    const imageLeft = hasDrawRect ? drawRect!.drawX : 0;
+    const imageTop = hasDrawRect ? drawRect!.drawY : 0;
+    const imageRight = hasDrawRect
+      ? drawRect!.drawX + drawRect!.drawWidth
+      : canvasWidth;
+    const imageBottom = hasDrawRect
+      ? drawRect!.drawY + drawRect!.drawHeight
+      : canvasHeight;
+
     switch (overlayPosition) {
       case 'top-left':
-        x = margin;
-        y = margin;
+        x = (hasDrawRect ? imageLeft : 0) + margin;
+        y = (hasDrawRect ? imageTop : 0) + margin;
         break;
       case 'top-right':
-        x = canvasWidth - scaledWidth - margin;
-        y = margin;
+        x = (hasDrawRect ? imageRight : canvasWidth) - scaledWidth - margin;
+        y = (hasDrawRect ? imageTop : 0) + margin;
         break;
       case 'bottom-left':
-        x = margin;
-        y = canvasHeight - scaledHeight - margin;
+        x = (hasDrawRect ? imageLeft : 0) + margin;
+        y = (hasDrawRect ? imageBottom : canvasHeight) - scaledHeight - margin;
         break;
       case 'bottom-right':
-        x = canvasWidth - scaledWidth - margin;
-        y = canvasHeight - scaledHeight - margin;
+        x = (hasDrawRect ? imageRight : canvasWidth) - scaledWidth - margin;
+        y = (hasDrawRect ? imageBottom : canvasHeight) - scaledHeight - margin;
         break;
       default:
         x = template.position.x;
@@ -216,7 +262,15 @@ export class CanvasRenderer {
     ctx: CanvasRenderingContext2D,
     template: Template,
     exifData: NormalizedExifData,
-    scaleFactor: number = 1
+    scaleFactor: number = 1,
+    options?: {
+      imageIsPortrait?: boolean;
+      overlayPosition?:
+        | 'top-left'
+        | 'top-right'
+        | 'bottom-left'
+        | 'bottom-right';
+    }
   ): void {
     const { style, position, fields } = template;
 
@@ -282,16 +336,63 @@ export class CanvasRenderer {
     ctx.globalAlpha = 1;
     ctx.fillStyle = style.textColor;
 
-    let currentY = scaledY + scaledPadding + scaledFontSize;
-    const textX =
-      position.alignment === 'center'
-        ? scaledX + scaledWidth / 2
-        : scaledX + scaledPadding;
+    // Improve readability for film-style (no background) with a soft glow
+    if (template.id === 'film') {
+      ctx.shadowColor = 'rgba(0, 0, 0, 0.85)';
+      ctx.shadowBlur = 6 * Math.max(1, scaleFactor);
+      ctx.shadowOffsetX = 0;
+      ctx.shadowOffsetY = 0;
+    } else {
+      ctx.shadowColor = 'transparent';
+      ctx.shadowBlur = 0;
+      ctx.shadowOffsetX = 0;
+      ctx.shadowOffsetY = 0;
+    }
 
-    // Render all wrapped text lines
-    for (const line of allTextLines) {
-      ctx.fillText(line, textX, currentY);
-      currentY += lineHeight;
+    const shouldRotate =
+      template.id === 'film' && options?.imageIsPortrait === true;
+
+    if (shouldRotate && options?.overlayPosition?.includes('right')) {
+      // Rotate 90 degrees at the right edge for portrait images
+      const isTop = options.overlayPosition === 'top-right';
+      const anchorX = scaledX + scaledWidth - scaledPadding;
+      const anchorY = isTop
+        ? scaledY + scaledPadding
+        : scaledY + (scaledHeight - scaledPadding);
+
+      ctx.save();
+      ctx.translate(anchorX, anchorY);
+      ctx.rotate(isTop ? Math.PI / 2 : -Math.PI / 2);
+      const prevAlign = ctx.textAlign;
+      const prevBaseline = ctx.textBaseline;
+      ctx.textAlign = 'left';
+      ctx.textBaseline = 'top';
+
+      // Render lines along the long edge
+      let offset = 0;
+      for (const line of allTextLines) {
+        ctx.fillText(line, isTop ? offset : -offset, 0);
+        offset += lineHeight;
+      }
+
+      // Restore context
+      ctx.textAlign = prevAlign;
+      ctx.textBaseline = prevBaseline as CanvasTextBaseline;
+      ctx.restore();
+    } else {
+      let currentY = scaledY + scaledPadding + scaledFontSize;
+      const textX =
+        position.alignment === 'center'
+          ? scaledX + scaledWidth / 2
+          : position.alignment === 'right'
+            ? scaledX + scaledWidth - scaledPadding
+            : scaledX + scaledPadding;
+
+      // Render all wrapped text lines
+      for (const line of allTextLines) {
+        ctx.fillText(line, textX, currentY);
+        currentY += lineHeight;
+      }
     }
   }
 

--- a/src/templates/film.ts
+++ b/src/templates/film.ts
@@ -1,0 +1,66 @@
+import type { Template } from '@/types/template';
+
+// Format to classic film date imprint like "'98.12.05"
+function formatFilmDate(value: string | null): string {
+  if (!value) return `'--.--.--`;
+
+  // Match common patterns: YYYY/MM/DD, YYYY-MM-DD, YYYY:MM:DD, etc.
+  const m = value.match(/(\d{4})[\/\-:.](\d{2})[\/\-:.](\d{2})/);
+  if (m) {
+    const [, yyyy, mm, dd] = m;
+    const yy = yyyy.slice(-2);
+    return `'${yy}.${mm}.${dd}`;
+  }
+
+  // Fallback: try Date parsing
+  const d = new Date(value);
+  if (!isNaN(d.getTime())) {
+    const yy = String(d.getFullYear()).slice(2);
+    const mm = String(d.getMonth() + 1).padStart(2, '0');
+    const dd = String(d.getDate()).padStart(2, '0');
+    return `'${yy}.${mm}.${dd}`;
+  }
+
+  // As a last resort, return original
+  return value;
+}
+
+export const filmTemplate: Template = {
+  id: 'film',
+  name: 'Film',
+  description: 'Retro film-camera date imprint style',
+  style: {
+    // Dot-matrix feel for film date imprint
+    fontFamily: "'DotGothic16', 'Courier New', monospace",
+    fontSize: 30,
+    // Amber/orange LED-like color
+    textColor: '#ff6a00',
+    // Transparent background to mimic direct imprint on photo
+    backgroundColor: '#000000',
+    opacity: 0,
+    padding: 10,
+    borderRadius: 0,
+  },
+  position: {
+    x: 20,
+    y: 20,
+    width: 300,
+    height: 40,
+    alignment: 'left',
+  },
+  fields: [
+    {
+      key: 'dateTime',
+      label: '',
+      visible: true,
+      format: (value) => formatFilmDate(value),
+    },
+    // Keep other fields but hidden for this style
+    { key: 'camera', label: 'Camera', visible: false },
+    { key: 'lens', label: 'Lens', visible: false },
+    { key: 'focalLength', label: 'Focal Length', visible: false },
+    { key: 'aperture', label: 'Aperture', visible: false },
+    { key: 'shutterSpeed', label: 'Shutter', visible: false },
+    { key: 'iso', label: 'ISO', visible: false },
+  ],
+};

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -2,13 +2,14 @@ import type { Template, TemplatePreset } from '@/types/template';
 import { minimalTemplate } from './minimal';
 import { classicTemplate } from './classic';
 import { modernTemplate } from './modern';
+import { filmTemplate } from './film';
 
 export const templates: Record<TemplatePreset, Template> = {
   minimal: minimalTemplate,
   classic: classicTemplate,
   modern: modernTemplate,
-  film: minimalTemplate, // Placeholder - will implement later
+  film: filmTemplate,
   technical: modernTemplate, // Placeholder - will implement later
 };
 
-export { minimalTemplate, classicTemplate, modernTemplate };
+export { minimalTemplate, classicTemplate, modernTemplate, filmTemplate };


### PR DESCRIPTION
New … template with dot-like font (DotGothic16), orange date imprint, glow for readability
- Date format to film-like with leading apostrophe: ''yy.mm.dd' (e.g. '25.08.30)
- Rotate imprint 90° on portrait when aligned to right; fixed positions: landscape->bottom-right, portrait->top-right