### PR TITLE
Migrate to Cloudflare Workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,6 @@ jobs:
 
       - name: TypeScript type check
         run: npx tsc --noEmit
+
+      - name: Build (static export)
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ npm run build
 ### Security Headers
 
 Security headers are applied in the Worker (`src/worker.ts`), including:
+
 - Content Security Policy (CSP)
 - Cross-Origin Policies (COOP/COEP)
 - Common hardening headers (XFO, XCTO, HSTS, Referrer-Policy)
-Note: `public/_headers` is not used on Workers.
+  Note: `public/_headers` is not used on Workers.
 
 ## 📁 Project Structure
 

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ npm run build
 - **State Management**: Zustand
 - **EXIF Processing**: exifr
 - **File Upload**: react-dropzone
-- **Deployment**: Cloudflare Workers/Pages
+- **Deployment**: Cloudflare Workers
 
 ## 🔧 Configuration
 
-### Cloudflare Workers/Pages Setup
+### Cloudflare Workers Setup
 
 1. **Build Command**: `npm run build`
 2. **Output Directory**: `dist`
@@ -63,11 +63,11 @@ npm run build
 
 ### Security Headers
 
-The app includes security headers in `_headers`:
-
-- Content Security Policy
-- Cross-Origin Policies
-- XSS Protection
+Security headers are applied in the Worker (`src/worker.ts`), including:
+- Content Security Policy (CSP)
+- Cross-Origin Policies (COOP/COEP)
+- Common hardening headers (XFO, XCTO, HSTS, Referrer-Policy)
+Note: `public/_headers` is not used on Workers.
 
 ## 📁 Project Structure
 
@@ -88,9 +88,9 @@ src/
 ## 🎨 Templates
 
 - **Minimal**: Clean, essential information
-- **Classic**: Traditional film-inspired layout
-- **Modern**: Contemporary design with icons
-- _More templates coming soon..._
+- **Classic**: Traditional layout
+- **Film**: Retro film-camera date imprint
+- **Technical**: Detailed specs (monospaced)
 
 ## 📋 Requirements
 
@@ -112,7 +112,7 @@ MIT License - see [LICENSE](LICENSE) for details.
 
 ## 🚀 Deployment
 
-### Cloudflare Workers/Pages
+### Cloudflare Workers
 
 This project is configured for deployment to Cloudflare Workers with custom domain support:
 
@@ -129,14 +129,14 @@ This project is configured for deployment to Cloudflare Workers with custom doma
 2. **Deployment Commands**:
 
    ```bash
-   # Build the project
+   # Build the project (static export)
    npm run build
 
-   # Deploy to preview
+   # Deploy to preview (Workers)
    npm run deploy:preview
 
-   # Deploy to production (metamark.kiakiraki.dev)
-   npm run deploy:production
+   # Deploy to production (Workers)
+   npm run deploy
    ```
 
 3. **Configuration**:
@@ -144,11 +144,9 @@ This project is configured for deployment to Cloudflare Workers with custom doma
    - **Output Directory**: `dist/`
    - **Wrangler Config**: `wrangler.toml`
 
-4. **Alternative: Cloudflare Pages Dashboard**:
-   - Framework preset: `Next.js (Static HTML Export)`
-   - Build command: `npm run build`
-   - Build output directory: `dist`
-   - Deploy command: leave empty
+4. **Notes**:
+   - The Worker serves files from `dist/` and injects security headers.
+   - Ensure DNS/custom domain is mapped to the Worker route in `wrangler.toml`.
 
 ## 🎯 MVP Status
 
@@ -156,11 +154,11 @@ This project is configured for deployment to Cloudflare Workers with custom doma
 
 - Image upload with drag & drop
 - EXIF metadata extraction
-- Basic template system (Minimal, Classic, Modern)
+- Basic template system (Minimal, Classic, Technical, Film)
 - Canvas rendering with overlays
 - High-quality image export
 - Responsive UI with dark/light themes
-- Static site generation for Cloudflare Workers/Pages
+- Static site generation for Cloudflare Workers
 
 🔄 **Coming Next**:
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,7 +7,6 @@ const nextConfig: NextConfig = {
   images: {
     unoptimized: true,
   },
-  assetPrefix: process.env.NODE_ENV === 'production' ? '' : '',
   typescript: {
     ignoreBuildErrors: false,
   },

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
+    "preview": "npx serve dist -l 3000",
     "lint": "eslint",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "deploy": "wrangler pages deploy",
-    "deploy:preview": "wrangler pages deploy --compatibility-date=2025-08-27",
-    "deploy:production": "wrangler pages deploy --env production"
+    "deploy": "wrangler deploy",
+    "deploy:preview": "wrangler deploy --env preview"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "lint": "eslint",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "deploy": "wrangler deploy",
-    "deploy:preview": "wrangler deploy --env preview"
+    "deploy": "npx wrangler@3 deploy",
+    "deploy:preview": "npx wrangler@3 deploy --env preview"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "lint": "eslint",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "deploy": "npx wrangler@3 deploy",
-    "deploy:preview": "npx wrangler@3 deploy --env preview"
+    "deploy": "npx wrangler@4 deploy",
+    "deploy:preview": "npx wrangler@4 deploy --env preview"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,5 @@
-/* eslint-disable @next/next/no-page-custom-font */
 import type { Metadata } from 'next';
-import { Geist, Geist_Mono } from 'next/font/google';
+import { Geist, Geist_Mono, DotGothic16 } from 'next/font/google';
 import './globals.css';
 import { ThemeProvider } from '@/contexts/ThemeContext';
 
@@ -12,6 +11,13 @@ const geistSans = Geist({
 const geistMono = Geist_Mono({
   variable: '--font-geist-mono',
   subsets: ['latin'],
+});
+
+// Filmテンプレート用フォントは next/font で自前配信
+const dotGothic = DotGothic16({
+  weight: '400',
+  subsets: ['latin'],
+  variable: '--font-dotgothic',
 });
 
 export const metadata: Metadata = {
@@ -26,21 +32,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <head>
-        {/* Dot-matrix style font for Film template */}
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link
-          rel="preconnect"
-          href="https://fonts.gstatic.com"
-          crossOrigin=""
-        />
-        <link
-          href="https://fonts.googleapis.com/css2?family=DotGothic16&display=swap"
-          rel="stylesheet"
-        />
-      </head>
+      <head />
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} ${dotGothic.variable} antialiased`}
       >
         <ThemeProvider>{children}</ThemeProvider>
       </body>

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -22,7 +22,9 @@ const worker = {
     // If not found and the client accepts HTML, fall back to index (for pretty URLs)
     if (response.status === 404 && acceptsHtml(request)) {
       const indexUrl = new URL('/index.html', url.origin);
-      response = await env.ASSETS.fetch(new Request(indexUrl.toString(), request));
+      response = await env.ASSETS.fetch(
+        new Request(indexUrl.toString(), request)
+      );
     }
 
     // Clone response and add headers
@@ -80,5 +82,8 @@ function setSecurityHeaders(res: Response): void {
   res.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
   res.headers.set('Cross-Origin-Opener-Policy', 'same-origin');
   res.headers.set('Cross-Origin-Embedder-Policy', 'require-corp');
-  res.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains; preload');
+  res.headers.set(
+    'Strict-Transport-Security',
+    'max-age=31536000; includeSubDomains; preload'
+  );
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,0 +1,84 @@
+// Minimal Cloudflare Worker to serve static assets from dist/ with security and cache headers
+// This avoids relying on Pages and centralizes headers in the Worker.
+
+interface Env {
+  // Bound by wrangler.toml [assets]
+  ASSETS: {
+    fetch: (request: Request) => Promise<Response>;
+  };
+}
+
+const worker = {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      return new Response('Method Not Allowed', { status: 405 });
+    }
+
+    // Try to serve from static assets
+    let response = await env.ASSETS.fetch(request);
+
+    // If not found and the client accepts HTML, fall back to index (for pretty URLs)
+    if (response.status === 404 && acceptsHtml(request)) {
+      const indexUrl = new URL('/index.html', url.origin);
+      response = await env.ASSETS.fetch(new Request(indexUrl.toString(), request));
+    }
+
+    // Clone response and add headers
+    const res = new Response(response.body, response);
+
+    // Security headers
+    const isHtml = isHtmlResponse(res);
+    if (isHtml) {
+      setSecurityHeaders(res);
+      // HTML: avoid caching
+      res.headers.set('Cache-Control', 'no-store');
+    } else {
+      // Static assets: long cache for hashed files, short for others
+      const longCache = isHashedAsset(url.pathname);
+      const cacheControl = longCache
+        ? 'public, max-age=31536000, immutable'
+        : 'public, max-age=3600, must-revalidate';
+      res.headers.set('Cache-Control', cacheControl);
+    }
+
+    return res;
+  },
+};
+
+export default worker;
+
+function isHtmlResponse(res: Response): boolean {
+  const ct = res.headers.get('Content-Type') || '';
+  return ct.includes('text/html');
+}
+
+function acceptsHtml(req: Request): boolean {
+  const accept = req.headers.get('Accept') || '';
+  return accept.includes('text/html');
+}
+
+function isHashedAsset(pathname: string): boolean {
+  // e.g. app-abcdef123456.js, chunk.e57805618994549f.js, etc.
+  return /\.[a-f0-9]{8,}\./i.test(pathname);
+}
+
+function setSecurityHeaders(res: Response): void {
+  const csp = [
+    "default-src 'self'",
+    "img-src 'self' data: blob:",
+    "style-src 'self' 'unsafe-inline'",
+    "font-src 'self'",
+    "script-src 'self'",
+    "connect-src 'self'",
+  ].join('; ');
+
+  res.headers.set('Content-Security-Policy', csp);
+  res.headers.set('X-Frame-Options', 'DENY');
+  res.headers.set('X-Content-Type-Options', 'nosniff');
+  res.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+  res.headers.set('Cross-Origin-Opener-Policy', 'same-origin');
+  res.headers.set('Cross-Origin-Embedder-Policy', 'require-corp');
+  res.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains; preload');
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,8 +1,11 @@
 name = "metamark"
-compatibility_date = "2025-08-27"
+compatibility_date = "2025-08-31"
+main = "src/worker.ts"
 
 [assets]
 directory = "dist"
+binding = "ASSETS"
+html_handling = "auto"
 
 [[routes]]
 pattern = "metamark.kiakiraki.dev"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,8 +5,11 @@ main = "src/worker.ts"
 [assets]
 directory = "dist"
 binding = "ASSETS"
-html_handling = "auto"
+html_handling = "force-trailing-slash"
 
 [[routes]]
 pattern = "metamark.kiakiraki.dev"
 custom_domain = true
+
+[env.preview]
+# Inherit top-level settings; no custom domain for preview (uses workers.dev)

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -12,4 +12,5 @@ pattern = "metamark.kiakiraki.dev"
 custom_domain = true
 
 [env.preview]
-# Inherit top-level settings; no custom domain for preview (uses workers.dev)
+name = "metamark"
+workers_dev = true


### PR DESCRIPTION
This PR migrates deployment from Cloudflare Pages to Cloudflare Workers and serves the static export from a Worker with security and cache headers.\n\nChanges\n- Add Worker: src/worker.ts (serves dist/, adds CSP/COOP/COEP, cache headers)\n- Wrangler config: set main=src/worker.ts, bind assets (ASSETS), html_handling=auto, keep custom domain route\n- Scripts: switch to wrangler deploy; add preview; remove Pages deploy scripts\n- Fonts: load DotGothic16 via next/font; remove external Google Fonts tags (COEP-safe)\n- Next config: remove unused assetPrefix\n- CI: add build step to catch build failures\n- Docs: update README to Workers-only, note that public/_headers is unused under Workers\n\nValidation\n- Lint, type-check, and Next.js Turbopack build succeed; static export generated in dist/\n\nFollow-ups\n- Configure Cloudflare API token/account in CI if automating deploy\n- Optionally add a deploy workflow (wrangler deploy) for main/preview branches\n