### PR TITLE
Ensure canvas is rendered before image download

### DIFF
--- a/src/services/canvasRenderer.ts
+++ b/src/services/canvasRenderer.ts
@@ -412,9 +412,11 @@ export class CanvasRenderer {
   }
 
   static async renderToBlob(options: RenderOptions): Promise<Blob> {
-    return new Promise((resolve, reject) => {
-      const { canvas, settings } = options;
+    await this.render(options);
 
+    const { canvas, settings } = options;
+
+    return new Promise((resolve, reject) => {
       canvas.toBlob(
         (blob) => {
           if (blob) {


### PR DESCRIPTION
## Summary
- Fix image export producing broken downloads on mobile by rendering to canvas before converting to blob

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7be33abdc832a95840582755c1d9d