### PR TITLE
fix: EXIF/Blob leaks, upload races, and Zustand/ThemeContext hygiene

### DIFF
--- a/src/components/editor/PositionSelector.tsx
+++ b/src/components/editor/PositionSelector.tsx
@@ -14,8 +14,12 @@ const POSITION_OPTIONS: { key: PositionPreset; label: string; icon: string }[] =
   ];
 
 export function PositionSelector() {
-  const { canvasSettings, updateCanvasSettings } = useSettingsStore();
-  const currentPosition = canvasSettings.overlayPosition;
+  const currentPosition = useSettingsStore(
+    (state) => state.canvasSettings.overlayPosition
+  );
+  const updateCanvasSettings = useSettingsStore(
+    (state) => state.updateCanvasSettings
+  );
 
   const handlePositionChange = (position: PositionPreset) => {
     updateCanvasSettings({ overlayPosition: position });

--- a/src/components/editor/TemplateSelector.tsx
+++ b/src/components/editor/TemplateSelector.tsx
@@ -8,7 +8,8 @@ import { PositionSelector } from './PositionSelector';
 import clsx from 'clsx';
 
 export function TemplateSelector() {
-  const { selectedTemplate, selectTemplate } = useTemplateStore();
+  const selectedTemplate = useTemplateStore((state) => state.selectedTemplate);
+  const selectTemplate = useTemplateStore((state) => state.selectTemplate);
 
   const templatePresets: {
     key: TemplatePreset;

--- a/src/components/export/ExportControls.tsx
+++ b/src/components/export/ExportControls.tsx
@@ -17,8 +17,11 @@ export function ExportControls() {
 
   const selectedImage = useSelectedImage();
   const getNormalizedData = useExifStore((state) => state.getNormalizedData);
-  const { selectedTemplate } = useTemplateStore();
-  const { canvasSettings, updateCanvasSettings } = useSettingsStore();
+  const selectedTemplate = useTemplateStore((state) => state.selectedTemplate);
+  const canvasSettings = useSettingsStore((state) => state.canvasSettings);
+  const updateCanvasSettings = useSettingsStore(
+    (state) => state.updateCanvasSettings
+  );
 
   const handleExport = async () => {
     if (!selectedImage || !selectedTemplate) return;

--- a/src/components/export/ExportControls.tsx
+++ b/src/components/export/ExportControls.tsx
@@ -54,15 +54,21 @@ export function ExportControls() {
         },
       });
 
-      // Download the blob
       const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `metamark_${selectedImage.name.replace(/\.[^/.]+$/, '')}.${canvasSettings.format}`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+      try {
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `metamark_${selectedImage.name.replace(/\.[^/.]+$/, '')}.${canvasSettings.format}`;
+        a.style.display = 'none';
+        document.body.appendChild(a);
+        try {
+          a.click();
+        } finally {
+          a.remove();
+        }
+      } finally {
+        URL.revokeObjectURL(url);
+      }
     } catch (error: unknown) {
       console.error('Export failed:', error);
       toast.error('Export failed. Please try again.');

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -5,7 +5,8 @@ import clsx from 'clsx';
 import { useToastStore } from '@/hooks/useToast';
 
 export function ToastContainer() {
-  const { toasts, removeToast } = useToastStore();
+  const toasts = useToastStore((state) => state.toasts);
+  const removeToast = useToastStore((state) => state.removeToast);
 
   return (
     <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2">

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -17,41 +17,55 @@ interface ThemeContextType {
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
+const isTheme = (value: unknown): value is Theme =>
+  value === 'light' || value === 'dark' || value === 'system';
+
 const themeStore = (() => {
   let currentTheme: Theme = 'system';
+  let initialized = false;
   const listeners = new Set<() => void>();
 
+  const notify = () => {
+    listeners.forEach((listener) => listener());
+  };
+
+  const ensureInitialized = () => {
+    if (initialized || typeof window === 'undefined') return;
+    initialized = true;
+    const saved = window.localStorage.getItem('theme');
+    if (isTheme(saved)) currentTheme = saved;
+    window.addEventListener('storage', (event) => {
+      if (event.key !== 'theme') return;
+      if (isTheme(event.newValue) && event.newValue !== currentTheme) {
+        currentTheme = event.newValue;
+        notify();
+      }
+    });
+  };
+
   const getSnapshot = (): Theme => {
-    if (typeof window === 'undefined') return currentTheme;
-    const savedTheme = localStorage.getItem('theme') as Theme | null;
-    return savedTheme ?? currentTheme;
+    ensureInitialized();
+    return currentTheme;
   };
 
   const getServerSnapshot = (): Theme => 'system';
 
   const subscribe = (listener: () => void) => {
+    ensureInitialized();
     listeners.add(listener);
-    if (typeof window === 'undefined') {
-      return () => listeners.delete(listener);
-    }
-    const handleStorage = (event: StorageEvent) => {
-      if (event.key === 'theme') {
-        listener();
-      }
-    };
-    window.addEventListener('storage', handleStorage);
     return () => {
       listeners.delete(listener);
-      window.removeEventListener('storage', handleStorage);
     };
   };
 
   const setTheme = (next: Theme) => {
+    ensureInitialized();
+    if (currentTheme === next) return;
     currentTheme = next;
     if (typeof window !== 'undefined') {
-      localStorage.setItem('theme', next);
+      window.localStorage.setItem('theme', next);
     }
-    listeners.forEach((listener) => listener());
+    notify();
   };
 
   return { getSnapshot, getServerSnapshot, subscribe, setTheme };

--- a/src/hooks/useCanvasRenderer.ts
+++ b/src/hooks/useCanvasRenderer.ts
@@ -24,19 +24,16 @@ export function useCanvasRenderer(currentImage: ProcessedImage | null) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [isRendering, setIsRendering] = useState(false);
 
-  const getNormalizedData = useExifStore((state) => state.getNormalizedData);
-  const normalizedData = useExifStore((state) => state.normalizedData);
-  const { selectedTemplate } = useTemplateStore();
-  const { canvasSettings } = useSettingsStore();
+  const currentExifData = useExifStore((state) =>
+    currentImage?.id ? state.normalizedData[currentImage.id] : undefined
+  );
+  const selectedTemplate = useTemplateStore((state) => state.selectedTemplate);
+  const canvasSettings = useSettingsStore((state) => state.canvasSettings);
 
   const { containerHeight, updateCanvasDisplaySize } = useResponsiveCanvas(
     canvasRef,
     currentImage
   );
-
-  const currentExifData = currentImage?.id
-    ? normalizedData[currentImage.id]
-    : undefined;
 
   useEffect(() => {
     const renderCanvas = async () => {
@@ -46,22 +43,17 @@ export function useCanvasRenderer(currentImage: ProcessedImage | null) {
 
       try {
         const image = await ImageProcessor.createImageElement(currentImage.url);
-        let exifData = getNormalizedData(currentImage.id);
 
         const { width, height } = CanvasRenderer.calculateOptimalSize(
           currentImage.width,
           currentImage.height
         );
 
-        if (!exifData) {
-          exifData = PLACEHOLDER_EXIF_DATA;
-        }
-
         await CanvasRenderer.render({
           canvas: canvasRef.current,
           image,
           template: selectedTemplate,
-          exifData,
+          exifData: currentExifData ?? PLACEHOLDER_EXIF_DATA,
           settings: {
             ...canvasSettings,
             width,
@@ -78,8 +70,13 @@ export function useCanvasRenderer(currentImage: ProcessedImage | null) {
 
     const timer = setTimeout(renderCanvas, 50);
     return () => clearTimeout(timer);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentImage, selectedTemplate, canvasSettings, currentExifData]);
+  }, [
+    currentImage,
+    selectedTemplate,
+    canvasSettings,
+    currentExifData,
+    updateCanvasDisplaySize,
+  ]);
 
   return {
     canvasRef,

--- a/src/hooks/useImageUpload.ts
+++ b/src/hooks/useImageUpload.ts
@@ -7,7 +7,9 @@ import { extractExifData, normalizeExifData } from '@/services/exifExtractor';
 import { useToast } from '@/hooks/useToast';
 
 export function useImageUpload() {
-  const { currentImage, setImage, clearImage } = useImageStore();
+  const currentImage = useImageStore((state) => state.currentImage);
+  const setImage = useImageStore((state) => state.setImage);
+  const clearImage = useImageStore((state) => state.clearImage);
   const setExifData = useExifStore((state) => state.setExifData);
   const setNormalizedData = useExifStore((state) => state.setNormalizedData);
   const toast = useToast();

--- a/src/hooks/useImageUpload.ts
+++ b/src/hooks/useImageUpload.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { useImageStore } from '@/stores/imageStore';
 import { useExifStore } from '@/stores/exifStore';
@@ -12,6 +12,14 @@ export function useImageUpload() {
   const setNormalizedData = useExifStore((state) => state.setNormalizedData);
   const toast = useToast();
 
+  const exifAbortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    return () => {
+      exifAbortRef.current?.abort();
+    };
+  }, []);
+
   const onDrop = useCallback(
     async (acceptedFiles: File[]) => {
       const file = acceptedFiles[0];
@@ -24,18 +32,26 @@ export function useImageUpload() {
         return;
       }
 
+      // Cancel any in-flight EXIF extraction from a previous drop so its
+      // result cannot land in the store after the image has been replaced.
+      exifAbortRef.current?.abort();
+      const controller = new AbortController();
+      exifAbortRef.current = controller;
+      const { signal } = controller;
+
       try {
         const imageFile = await ImageProcessor.loadImageFile(file);
         setImage(imageFile);
 
-        // Extract EXIF data in background
         extractExifData(file)
           .then((exifData) => {
+            if (signal.aborted) return;
             setExifData(imageFile.id, exifData);
             const normalized = normalizeExifData(exifData);
             setNormalizedData(imageFile.id, normalized);
           })
           .catch((error: unknown) => {
+            if (signal.aborted) return;
             console.error('Error processing EXIF data:', error);
             toast.error('Failed to extract EXIF data.');
           });

--- a/src/services/imageProcessor.ts
+++ b/src/services/imageProcessor.ts
@@ -9,7 +9,6 @@ export class ImageProcessor {
       img.onload = () => {
         const imageFile: ImageFile = {
           id: crypto.randomUUID(),
-          file,
           url,
           name: file.name,
           size: file.size,

--- a/src/stores/imageStore.ts
+++ b/src/stores/imageStore.ts
@@ -15,10 +15,15 @@ export const useImageStore = create<ImageState>((set, get) => ({
   currentImage: null,
 
   setImage: (image) => {
-    // Clean up previous image URL if exists
-    const currentImage = get().currentImage;
-    if (currentImage?.url) {
-      ImageProcessor.cleanupImageUrl(currentImage.url);
+    const previous = get().currentImage;
+    if (previous) {
+      if (previous.url) {
+        ImageProcessor.cleanupImageUrl(previous.url);
+      }
+      if (previous.processedUrl) {
+        ImageProcessor.cleanupImageUrl(previous.processedUrl);
+      }
+      useExifStore.getState().clearExifData(previous.id);
     }
 
     set({

--- a/src/stores/templateStore.ts
+++ b/src/stores/templateStore.ts
@@ -28,6 +28,3 @@ export const useTemplateStore = create<TemplateState>((set) => ({
         : null,
     })),
 }));
-
-// Set default template
-useTemplateStore.getState().selectTemplate('minimal');

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -1,6 +1,5 @@
 export interface ImageFile {
   id: string;
-  file: File;
   url: string;
   name: string;
   size: number;


### PR DESCRIPTION
## Summary

- **Memory and race fixes**: `imageStore.setImage` now revokes the previous Blob URLs and clears the previous image's EXIF data so `exifStore` no longer accumulates stale entries on consecutive uploads. `ImageFile.file: File` is dropped so the raw buffer is not pinned by the store. Background EXIF extraction in `useImageUpload` is guarded by an `AbortController` so a slow Promise from a previous drop cannot land in the new image's slot. The export flow wraps `revokeObjectURL` in `try/finally` so the Blob URL is always released even if the anchor click path throws.
- **Zustand selector hygiene**: `useCanvasRenderer`, `useImageUpload`, `ExportControls`, `TemplateSelector`, `PositionSelector`, and `Toast` switch from whole-store destructuring to atomic selectors so each consumer re-renders only when its slice changes. `PositionSelector` subscribes to `canvasSettings.overlayPosition` directly. The `react-hooks/exhaustive-deps` eslint-disable on `useCanvasRenderer`'s render effect is removed. The redundant `selectTemplate('minimal')` initialization call in `templateStore` is dropped.
- **ThemeContext refactor**: `getSnapshot` returns a cached module-level `currentTheme` instead of reading `localStorage` on every call (which `useSyncExternalStore` invokes frequently). The `storage` event listener is registered once at module init, theme values are validated with an `isTheme` guard, and `setTheme` skips no-op writes.

## Test plan

- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm test` (19/19 passing)
- [x] `npm run build` (static export to `dist/`)
- [ ] Manual: drop image A, then image B in succession — verify B's EXIF replaces A's (no stale fields), and that the rendered overlay reflects B's metadata
- [ ] Manual: export PNG and JPEG and confirm the file downloads with the expected filename and quality
- [ ] Manual: switch templates and overlay positions while an image is loaded — canvas re-renders correctly
- [ ] Manual: toggle theme (light/dark/system) and confirm the document class follows; open a second tab, change theme there, and confirm the first tab updates via the `storage` event

🤖 Generated with [Claude Code](https://claude.com/claude-code)