### PR TITLE
perf: improve preview downscaling quality

### DIFF
--- a/src/hooks/useCanvasRenderer.ts
+++ b/src/hooks/useCanvasRenderer.ts
@@ -6,7 +6,62 @@ import { ImageProcessor } from '@/services/imageProcessor';
 import { CanvasRenderer } from '@/services/canvasRenderer';
 import type { NormalizedExifData } from '@/types/exif';
 import type { ProcessedImage } from '@/types/image';
-import { useResponsiveCanvas } from './useResponsiveCanvas';
+import type { Template } from '@/types/template';
+import { getDisplayBounds, useResponsiveCanvas } from './useResponsiveCanvas';
+
+// 2x oversample over the on-screen size: keeps a Retina-grade source
+// for the browser's CSS scaler while letting step-down do the heavy
+// lifting on the source-image side. Higher values reintroduce the
+// big CSS scaling we're trying to avoid.
+const PREVIEW_OVERSAMPLE = 2;
+
+// Pick a render size for the preview canvas that matches the on-screen
+// display, with a fixed oversample factor. We estimate the final canvas
+// aspect ratio (image + bottom-padding overlay) at full resolution first
+// — bottom-padding height is recomputed inside render at the new scale
+// so the result is close-enough; useResponsiveCanvas re-fits CSS afterwards.
+function computePreviewRenderSize(
+  imageWidth: number,
+  imageHeight: number,
+  template: Template,
+  exifData: NormalizedExifData
+): { width: number; height: number } {
+  const { width: fullW, height: fullH } = CanvasRenderer.calculateOptimalSize(
+    imageWidth,
+    imageHeight
+  );
+  const bpFull = CanvasRenderer.estimateBottomPaddingHeight(
+    template,
+    exifData,
+    fullW,
+    fullH
+  );
+  const totalFullH = fullH + bpFull;
+  const fullAspect = fullW / totalFullH;
+
+  const { maxDisplayWidth, maxDisplayHeight } = getDisplayBounds();
+  let displayCanvasW: number;
+  let displayCanvasH: number;
+  if (fullAspect > maxDisplayWidth / maxDisplayHeight) {
+    displayCanvasW = maxDisplayWidth;
+    displayCanvasH = displayCanvasW / fullAspect;
+  } else {
+    displayCanvasH = maxDisplayHeight;
+    displayCanvasW = displayCanvasH * fullAspect;
+  }
+
+  // settings.width/height represent the image area (without bottom padding);
+  // render() re-adds the padding internally. Convert from full-canvas display
+  // size back to image-area display size.
+  const imageAreaRatio = totalFullH > 0 ? fullH / totalFullH : 1;
+  const displayBaseW = displayCanvasW;
+  const displayBaseH = displayCanvasH * imageAreaRatio;
+
+  return {
+    width: Math.max(1, Math.round(displayBaseW * PREVIEW_OVERSAMPLE)),
+    height: Math.max(1, Math.round(displayBaseH * PREVIEW_OVERSAMPLE)),
+  };
+}
 
 const PLACEHOLDER_EXIF_DATA: NormalizedExifData = {
   camera: 'Loading...',
@@ -44,20 +99,24 @@ export function useCanvasRenderer(currentImage: ProcessedImage | null) {
       try {
         const image = await ImageProcessor.createImageElement(currentImage.url);
 
-        const { width, height } = CanvasRenderer.calculateOptimalSize(
-          currentImage.width,
-          currentImage.height
-        );
+        const exifData = currentExifData ?? PLACEHOLDER_EXIF_DATA;
+        const { width: renderWidth, height: renderHeight } =
+          computePreviewRenderSize(
+            currentImage.width,
+            currentImage.height,
+            selectedTemplate,
+            exifData
+          );
 
         await CanvasRenderer.render({
           canvas: canvasRef.current,
           image,
           template: selectedTemplate,
-          exifData: currentExifData ?? PLACEHOLDER_EXIF_DATA,
+          exifData,
           settings: {
             ...canvasSettings,
-            width,
-            height,
+            width: renderWidth,
+            height: renderHeight,
           },
         });
         updateCanvasDisplaySize();

--- a/src/hooks/useResponsiveCanvas.ts
+++ b/src/hooks/useResponsiveCanvas.ts
@@ -1,6 +1,26 @@
 import { useState, useCallback, useEffect, type RefObject } from 'react';
 import type { ProcessedImage } from '@/types/image';
 
+export function getDisplayBounds(): {
+  maxDisplayWidth: number;
+  maxDisplayHeight: number;
+} {
+  const windowWidth = typeof window !== 'undefined' ? window.innerWidth : 1024;
+  const isMobile = windowWidth < 768;
+  const isTablet = windowWidth < 1024;
+  const horizontalMargin = 40;
+
+  const maxDisplayWidth = isMobile
+    ? Math.min(300, windowWidth - horizontalMargin)
+    : isTablet
+      ? Math.min(500, windowWidth - horizontalMargin)
+      : Math.min(700, windowWidth - horizontalMargin);
+
+  const maxDisplayHeight = isMobile ? 400 : isTablet ? 500 : 600;
+
+  return { maxDisplayWidth, maxDisplayHeight };
+}
+
 export function useResponsiveCanvas(
   canvasRef: RefObject<HTMLCanvasElement | null>,
   currentImage: ProcessedImage | null
@@ -20,20 +40,7 @@ export function useResponsiveCanvas(
     const logicalHeight = canvas.height / devicePixelRatio;
     const canvasAspectRatio = logicalWidth / logicalHeight;
 
-    const windowWidth =
-      typeof window !== 'undefined' ? window.innerWidth : 1024;
-    const isMobile = windowWidth < 768;
-    const isTablet = windowWidth < 1024;
-
-    const horizontalMargin = 40;
-
-    const maxDisplayWidth = isMobile
-      ? Math.min(300, windowWidth - horizontalMargin)
-      : isTablet
-        ? Math.min(500, windowWidth - horizontalMargin)
-        : Math.min(700, windowWidth - horizontalMargin);
-
-    const maxDisplayHeight = isMobile ? 400 : isTablet ? 500 : 600;
+    const { maxDisplayWidth, maxDisplayHeight } = getDisplayBounds();
 
     let displayWidth, displayHeight;
 

--- a/src/services/canvasRenderer.ts
+++ b/src/services/canvasRenderer.ts
@@ -121,7 +121,10 @@ export class CanvasRenderer {
     // we step the source down by halves first — repeated bilinear passes
     // approximate Lanczos and avoid the moire/aliasing a single big drawImage
     // produces when the destination is much smaller than the source.
-    const targetPixelWidth = Math.max(1, Math.round(drawWidth * devicePixelRatio));
+    const targetPixelWidth = Math.max(
+      1,
+      Math.round(drawWidth * devicePixelRatio)
+    );
     const targetPixelHeight = Math.max(
       1,
       Math.round(drawHeight * devicePixelRatio)
@@ -804,7 +807,10 @@ export class CanvasRenderer {
       currentWidth > targetPixelWidth * 2 &&
       currentHeight > targetPixelHeight * 2
     ) {
-      const nextWidth = Math.max(targetPixelWidth, Math.floor(currentWidth / 2));
+      const nextWidth = Math.max(
+        targetPixelWidth,
+        Math.floor(currentWidth / 2)
+      );
       const nextHeight = Math.max(
         targetPixelHeight,
         Math.floor(currentHeight / 2)

--- a/src/services/canvasRenderer.ts
+++ b/src/services/canvasRenderer.ts
@@ -83,6 +83,10 @@ export class CanvasRenderer {
     // Scale the context to ensure correct drawing operations
     ctx.scale(devicePixelRatio, devicePixelRatio);
 
+    // Use high-quality interpolation when the browser scales the source image
+    ctx.imageSmoothingEnabled = true;
+    ctx.imageSmoothingQuality = 'high';
+
     // Clear canvas
     ctx.clearRect(0, 0, canvasWidth, canvasHeight);
 
@@ -113,8 +117,21 @@ export class CanvasRenderer {
       }
     }
 
-    // Draw image with preserved aspect ratio
-    ctx.drawImage(image, drawX, drawY, drawWidth, drawHeight);
+    // Draw image with preserved aspect ratio. For very large source images
+    // we step the source down by halves first — repeated bilinear passes
+    // approximate Lanczos and avoid the moire/aliasing a single big drawImage
+    // produces when the destination is much smaller than the source.
+    const targetPixelWidth = Math.max(1, Math.round(drawWidth * devicePixelRatio));
+    const targetPixelHeight = Math.max(
+      1,
+      Math.round(drawHeight * devicePixelRatio)
+    );
+    const drawableSource = this.stepDownSource(
+      image,
+      targetPixelWidth,
+      targetPixelHeight
+    );
+    ctx.drawImage(drawableSource, drawX, drawY, drawWidth, drawHeight);
 
     // Load required fonts declared by the template
     if (template.fontRequirements?.length) {
@@ -735,6 +752,79 @@ export class CanvasRenderer {
         settings.quality
       );
     });
+  }
+
+  // Used by the preview hook to size its render canvas to the display
+  // before rendering. For bottom-padding templates the final canvas is
+  // taller than the image; without this we'd guess the wrong aspect ratio.
+  static estimateBottomPaddingHeight(
+    template: Template,
+    exifData: NormalizedExifData,
+    baseWidth: number,
+    baseHeight: number
+  ): number {
+    if (template.layout !== 'bottom-padding') return 0;
+    const scaleFactor = Math.min(baseWidth, baseHeight) / 1000;
+    return this.calculateDynamicTemplateHeight(
+      template,
+      exifData,
+      scaleFactor,
+      baseWidth
+    );
+  }
+
+  // Half-step (pyramid) downsample: keep halving the source onto an
+  // offscreen canvas until it is within 2x of the target. The browser's
+  // single-shot drawImage degrades sharply when the source is many times
+  // larger than the destination; iterative bilinear passes are visually
+  // close to Lanczos at a fraction of the cost.
+  private static stepDownSource(
+    source: HTMLImageElement,
+    targetPixelWidth: number,
+    targetPixelHeight: number
+  ): HTMLImageElement | HTMLCanvasElement {
+    if (typeof document === 'undefined') return source;
+
+    const sourceWidth = source.naturalWidth || source.width;
+    const sourceHeight = source.naturalHeight || source.height;
+    if (!sourceWidth || !sourceHeight) return source;
+
+    if (
+      sourceWidth <= targetPixelWidth * 2 &&
+      sourceHeight <= targetPixelHeight * 2
+    ) {
+      return source;
+    }
+
+    let current: HTMLImageElement | HTMLCanvasElement = source;
+    let currentWidth = sourceWidth;
+    let currentHeight = sourceHeight;
+
+    while (
+      currentWidth > targetPixelWidth * 2 &&
+      currentHeight > targetPixelHeight * 2
+    ) {
+      const nextWidth = Math.max(targetPixelWidth, Math.floor(currentWidth / 2));
+      const nextHeight = Math.max(
+        targetPixelHeight,
+        Math.floor(currentHeight / 2)
+      );
+
+      const offCanvas = document.createElement('canvas');
+      offCanvas.width = nextWidth;
+      offCanvas.height = nextHeight;
+      const offCtx = offCanvas.getContext('2d');
+      if (!offCtx) return current;
+      offCtx.imageSmoothingEnabled = true;
+      offCtx.imageSmoothingQuality = 'high';
+      offCtx.drawImage(current, 0, 0, nextWidth, nextHeight);
+
+      current = offCanvas;
+      currentWidth = nextWidth;
+      currentHeight = nextHeight;
+    }
+
+    return current;
   }
 
   static calculateOptimalSize(


### PR DESCRIPTION
## Summary

- 画面プレビューのジャギー/モアレを軽減。
- `ctx.imageSmoothingQuality = 'high'` を明示し、`drawImage` 直前にピラミッド型の段階縮小(オフスクリーンcanvasで半分ずつ)を挟んで Lanczos に近い品質を稼ぐ。
- プレビュー用canvasの内部解像度を「表示サイズ × 2(オーバーサンプル)」に絞り、これまで CSS が引き受けていた約 6 倍の縮小を 2 倍まで圧縮。書き出しは別経路(`ExportControls.tsx` のテンポラリcanvas)なので画質に影響なし。
- `useResponsiveCanvas` から `getDisplayBounds()` を抽出して、レンダリング前のサイズ見積りでも再利用。
- `CanvasRenderer.estimateBottomPaddingHeight()` を public 化(bottom-padding テンプレートのアスペクト比事前計算用)。

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm test`
- [ ] `npm run dev` で大きめの写真を読み込み、各テンプレートでプレビューが綺麗になっているか目視確認
- [ ] bottom-padding 系テンプレート(film など)で、プレビューと書き出し画像の文字比率に大きな違和感がないか確認(scaleFactor の Math.max(12, …) によるわずかな差は仕様)
- [ ] エクスポートしたファイルがフル解像度のままであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)