### PR TITLE
feat(caption): refresh typography and normalize Sony model names

### DIFF
--- a/src/services/__tests__/cameraNameFormatter.test.ts
+++ b/src/services/__tests__/cameraNameFormatter.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { formatSonyModel } from '../cameraNameFormatter';
+
+describe('formatSonyModel', () => {
+  describe('ILCE (E-mount α)', () => {
+    it.each([
+      ['ILCE-1', 'α1'],
+      ['ILCE-1M2', 'α1 II'],
+      ['ILCE-7M4', 'α7 IV'],
+      ['ILCE-7RM5', 'α7R V'],
+      ['ILCE-7SM3', 'α7S III'],
+      ['ILCE-7CM2', 'α7C II'],
+      ['ILCE-7C', 'α7C'],
+      ['ILCE-6700', 'α6700'],
+      ['ILCE-9M3', 'α9 III'],
+    ])('%s → %s', (input, expected) => {
+      expect(formatSonyModel('SONY', input)).toBe(expected);
+    });
+  });
+
+  describe('ILCA (A-mount α)', () => {
+    it('ILCA-99M2 → α99 II', () => {
+      expect(formatSonyModel('SONY', 'ILCA-99M2')).toBe('α99 II');
+    });
+  });
+
+  describe('DSC (Cybershot)', () => {
+    it.each([
+      ['DSC-RX100M7', 'RX100 VII'],
+      ['DSC-RX1RM2', 'RX1R II'],
+      ['DSC-RX10M4', 'RX10 IV'],
+      ['DSC-WX500', 'WX500'],
+    ])('%s → %s', (input, expected) => {
+      expect(formatSonyModel('SONY', input)).toBe(expected);
+    });
+  });
+
+  describe('non-Sony manufacturers pass through', () => {
+    it('Canon EOS R5 returns model unchanged', () => {
+      expect(formatSonyModel('Canon', 'EOS R5')).toBe('EOS R5');
+    });
+
+    it('Nikon Z 9 returns model unchanged', () => {
+      expect(formatSonyModel('NIKON CORPORATION', 'NIKON Z 9')).toBe(
+        'NIKON Z 9'
+      );
+    });
+  });
+
+  describe('null and empty inputs', () => {
+    it('null model returns null', () => {
+      expect(formatSonyModel('SONY', null)).toBeNull();
+    });
+
+    it('undefined model returns null', () => {
+      expect(formatSonyModel('SONY', undefined)).toBeNull();
+    });
+
+    it('null make returns model unchanged', () => {
+      expect(formatSonyModel(null, 'ILCE-7M4')).toBe('ILCE-7M4');
+    });
+
+    it('empty make returns model unchanged', () => {
+      expect(formatSonyModel('', 'ILCE-7M4')).toBe('ILCE-7M4');
+    });
+  });
+
+  describe('fallbacks for unknown patterns', () => {
+    it('NEX-7 (unsupported family) returns original', () => {
+      expect(formatSonyModel('SONY', 'NEX-7')).toBe('NEX-7');
+    });
+
+    it('ILCE with garbage suffix returns original', () => {
+      expect(formatSonyModel('SONY', 'ILCE-FOO')).toBe('ILCE-FOO');
+    });
+  });
+
+  describe('make casing variants', () => {
+    it('mixed-case "Sony" works', () => {
+      expect(formatSonyModel('Sony', 'ILCE-1M2')).toBe('α1 II');
+    });
+
+    it('"Sony Group Corporation" still matches', () => {
+      expect(formatSonyModel('Sony Group Corporation', 'ILCE-1M2')).toBe(
+        'α1 II'
+      );
+    });
+
+    it('whitespace around make is tolerated', () => {
+      expect(formatSonyModel('  SONY  ', 'ILCE-7M4')).toBe('α7 IV');
+    });
+  });
+});

--- a/src/services/__tests__/exifExtractor.test.ts
+++ b/src/services/__tests__/exifExtractor.test.ts
@@ -13,14 +13,33 @@ describe('normalizeExifData', () => {
 
     const result = normalizeExifData(exifData);
 
-    expect(result.camera).toBe('Sony ILCE-7M4');
+    expect(result.camera).toBe('Sony α7 IV');
     expect(result.cameraMake).toBe('Sony');
-    expect(result.cameraModel).toBe('ILCE-7M4');
+    expect(result.cameraModel).toBe('α7 IV');
     expect(result.lens).toBe('Sony FE 24-70mm F2.8 GM');
     expect(result.focalLength).toBe('50mm');
     expect(result.iso).toBe('ISO 100');
     expect(result.aperture).toBe('f/2.8');
     expect(result.shutterSpeed).toBe('1/250s');
+  });
+
+  it('passes through non-Sony model names', () => {
+    const exifData: ExifData = {
+      camera: { make: 'Canon', model: 'EOS R5' },
+    };
+
+    const result = normalizeExifData(exifData);
+    expect(result.camera).toBe('Canon EOS R5');
+    expect(result.cameraModel).toBe('EOS R5');
+  });
+
+  it('leaves unsupported Sony families untouched', () => {
+    const exifData: ExifData = {
+      camera: { make: 'SONY', model: 'NEX-7' },
+    };
+
+    const result = normalizeExifData(exifData);
+    expect(result.cameraModel).toBe('NEX-7');
   });
 
   it('returns null for missing fields', () => {

--- a/src/services/cameraNameFormatter.ts
+++ b/src/services/cameraNameFormatter.ts
@@ -1,0 +1,60 @@
+const ROMAN_MARKS: Record<string, string> = {
+  '2': 'II',
+  '3': 'III',
+  '4': 'IV',
+  '5': 'V',
+  '6': 'VI',
+  '7': 'VII',
+  '8': 'VIII',
+  '9': 'IX',
+};
+
+const ILCE_PATTERN = /^ILCE-(\d+)([RSC])?(?:M(\d+))?$/;
+const ILCA_PATTERN = /^ILCA-(\d+)(?:M(\d+))?$/;
+const DSC_PATTERN = /^DSC-([A-Z]+\d+[A-Z]*?)(?:M(\d+))?$/;
+
+function isSonyMake(make: string | null | undefined): boolean {
+  return !!make && make.trim().toUpperCase().startsWith('SONY');
+}
+
+function markSuffix(markDigit: string | undefined): string | null {
+  if (!markDigit) return '';
+  const roman = ROMAN_MARKS[markDigit];
+  return roman ? ` ${roman}` : null;
+}
+
+export function formatSonyModel(
+  make: string | null | undefined,
+  model: string | null | undefined
+): string | null {
+  if (!model) return null;
+  if (!isSonyMake(make)) return model;
+
+  const normalized = model.trim().toUpperCase();
+
+  const ilce = ILCE_PATTERN.exec(normalized);
+  if (ilce) {
+    const [, digits, variant, mark] = ilce;
+    const suffix = markSuffix(mark);
+    if (suffix === null) return model;
+    return `α${digits}${variant ?? ''}${suffix}`;
+  }
+
+  const ilca = ILCA_PATTERN.exec(normalized);
+  if (ilca) {
+    const [, digits, mark] = ilca;
+    const suffix = markSuffix(mark);
+    if (suffix === null) return model;
+    return `α${digits}${suffix}`;
+  }
+
+  const dsc = DSC_PATTERN.exec(normalized);
+  if (dsc) {
+    const [, captured, mark] = dsc;
+    const suffix = markSuffix(mark);
+    if (suffix === null) return model;
+    return `${captured}${suffix}`;
+  }
+
+  return model;
+}

--- a/src/services/canvasRenderer.ts
+++ b/src/services/canvasRenderer.ts
@@ -484,11 +484,7 @@ export class CanvasRenderer {
       (value): value is string => !!value
     );
     const titleText =
-      titlePieces.length > 0
-        ? titlePieces.join('  ')
-        : makeText
-          ? null
-          : 'N/A';
+      titlePieces.length > 0 ? titlePieces.join('  ') : makeText ? null : 'N/A';
     const titleWeight = 600;
     measureCtx.font = `${titleWeight} ${titleFontSize}px ${template.style.fontFamily}`;
     const titleLines = titleText

--- a/src/services/canvasRenderer.ts
+++ b/src/services/canvasRenderer.ts
@@ -34,13 +34,25 @@ interface CaptionLayout {
   padding: number;
   bodyFontSize: number;
   bodyLineHeight: number;
+  paramsFontSize: number;
+  paramsLineHeight: number;
   titleFontSize: number;
   titleLineHeight: number;
+  makeFontSize: number;
+  makeLineHeight: number;
+  makeLetterSpacing: string;
+  metaFontSize: number;
+  metaLineHeight: number;
   columnGap: number;
   leftColumnWidth: number;
   rightColumnWidth: number;
+  contentHeight: number;
+  makeToTitleGap: number;
+  rightRowGap: number;
+  makeText: string | null;
   titleLines: string[];
-  rightBodyLines: string[];
+  paramsLines: string[];
+  dateLines: string[];
 }
 
 let captionLayoutCache: {
@@ -441,77 +453,133 @@ export class CanvasRenderer {
     const measureCtx = ctx;
     const padding = template.style.padding * scaleFactor;
     const bodyFontSize = Math.max(12, template.style.fontSize * scaleFactor);
-    const titleFontSize = Math.max(bodyFontSize * 1.6, bodyFontSize + 6);
+    const titleFontSize = Math.max(bodyFontSize * 1.7, bodyFontSize + 8);
     const titleLineHeight = titleFontSize * 1.15;
     const bodyLineHeight = bodyFontSize * 1.4;
-    const columnGap = Math.max(12, bodyFontSize * 0.8);
+    const paramsFontSize = Math.max(13, bodyFontSize * 1.15);
+    const paramsLineHeight = paramsFontSize * 1.4;
+    const makeFontSize = Math.max(12, bodyFontSize * 1.05);
+    const makeLineHeight = makeFontSize * 1.2;
+    const makeLetterSpacing = '0.18em';
+    const metaFontSize = Math.max(11, bodyFontSize * 0.85);
+    const metaLineHeight = metaFontSize * 1.3;
+    const columnGap = Math.max(16, bodyFontSize * 1.25);
+    const makeToTitleGap = makeFontSize * 0.55;
+    const rightRowGap = bodyFontSize * 0.45;
     const textAreaWidth = Math.max(0, availableWidth - padding * 2);
 
-    const leftColumnWidth = Math.max(0, Math.floor(textAreaWidth * 0.58));
+    const leftColumnWidth = Math.max(
+      0,
+      Math.floor((textAreaWidth - columnGap) * 0.62)
+    );
     const rightColumnWidth = Math.max(
       0,
       textAreaWidth - leftColumnWidth - columnGap
     );
 
     const { make, model } = this.getCaptionCameraParts(exifData);
-    const titleItems = [make, model].filter(
+    const makeText = make ? make.toUpperCase() : null;
+
+    const titlePieces = [model, exifData.lens].filter(
       (value): value is string => !!value
     );
-    if (titleItems.length === 0) {
-      titleItems.push('N/A');
-    }
-
-    const titleLines: string[] = [];
+    const titleText =
+      titlePieces.length > 0
+        ? titlePieces.join('  ')
+        : makeText
+          ? null
+          : 'N/A';
     const titleWeight = 600;
     measureCtx.font = `${titleWeight} ${titleFontSize}px ${template.style.fontFamily}`;
-    for (const item of titleItems) {
-      titleLines.push(...this.wrapText(measureCtx, item, leftColumnWidth));
-    }
+    const titleLines = titleText
+      ? this.wrapText(measureCtx, titleText, leftColumnWidth)
+      : [];
 
-    const isoValue = exifData.iso
-      ? exifData.iso.replace(/^ISO\s+/i, '').trim()
+    const apertureText = exifData.aperture
+      ? exifData.aperture.replace(/^f\//i, 'ƒ/')
       : null;
-    const safeIsoValue = isoValue && isoValue.length > 0 ? isoValue : null;
+    const paramsParts = [
+      exifData.focalLength,
+      apertureText,
+      exifData.shutterSpeed,
+      exifData.iso,
+    ].filter((value): value is string => !!value);
+    const paramsText =
+      paramsParts.length > 0 ? paramsParts.join('  ·  ') : null;
 
-    const rightItems: Array<{ label: string; value: string | null }> = [
-      { label: 'Lens', value: exifData.lens },
-      { label: 'Focal', value: exifData.focalLength },
-      { label: 'Aperture', value: exifData.aperture },
-      { label: 'Shutter', value: exifData.shutterSpeed },
-      { label: 'ISO', value: safeIsoValue },
-      { label: 'Date', value: exifData.dateTime },
-    ];
+    measureCtx.font = `${paramsFontSize}px ${template.style.fontFamily}`;
+    const paramsLines = paramsText
+      ? this.wrapText(measureCtx, paramsText, rightColumnWidth)
+      : [];
 
-    const rightBodyLines: string[] = [];
-    measureCtx.font = `${bodyFontSize}px ${template.style.fontFamily}`;
-    for (const item of rightItems) {
-      const text = `${item.label}: ${item.value ?? 'N/A'}`;
-      rightBodyLines.push(...this.wrapText(measureCtx, text, rightColumnWidth));
-    }
+    const dateText = exifData.dateTime
+      ? exifData.dateTime.replace(/\//g, '.')
+      : null;
+    measureCtx.font = `${metaFontSize}px ${template.style.fontFamily}`;
+    const dateLines = dateText
+      ? this.wrapText(measureCtx, dateText, rightColumnWidth)
+      : [];
 
-    const titleHeight =
-      titleLines.length > 0
-        ? titleFontSize + (titleLines.length - 1) * titleLineHeight
-        : 0;
-    const rightBodyHeight =
-      rightBodyLines.length > 0
-        ? bodyFontSize + (rightBodyLines.length - 1) * bodyLineHeight
-        : 0;
+    const blockHeight = (
+      lines: string[],
+      fontSize: number,
+      lineHeight: number
+    ) => (lines.length === 0 ? 0 : fontSize + (lines.length - 1) * lineHeight);
 
-    const contentHeight = Math.max(titleHeight, rightBodyHeight);
+    const makeBlockHeight = makeText ? makeFontSize : 0;
+    const titleBlockHeight = blockHeight(
+      titleLines,
+      titleFontSize,
+      titleLineHeight
+    );
+    const leftHeight =
+      makeBlockHeight +
+      (makeBlockHeight && titleBlockHeight ? makeToTitleGap : 0) +
+      titleBlockHeight;
+
+    const paramsBlockHeight = blockHeight(
+      paramsLines,
+      paramsFontSize,
+      paramsLineHeight
+    );
+    const dateBlockHeight = blockHeight(
+      dateLines,
+      metaFontSize,
+      metaLineHeight
+    );
+    const rightBlocks = [paramsBlockHeight, dateBlockHeight].filter(
+      (h) => h > 0
+    );
+    const rightHeight =
+      rightBlocks.reduce((sum, h) => sum + h, 0) +
+      Math.max(0, rightBlocks.length - 1) * rightRowGap;
+
+    const contentHeight = Math.max(leftHeight, rightHeight);
 
     const layout: CaptionLayout = {
       height: padding + contentHeight + padding,
       padding,
       bodyFontSize,
       bodyLineHeight,
+      paramsFontSize,
+      paramsLineHeight,
       titleFontSize,
       titleLineHeight,
+      makeFontSize,
+      makeLineHeight,
+      makeLetterSpacing,
+      metaFontSize,
+      metaLineHeight,
       columnGap,
       leftColumnWidth,
       rightColumnWidth,
+      contentHeight,
+      makeToTitleGap,
+      rightRowGap,
+      makeText,
       titleLines,
-      rightBodyLines,
+      paramsLines,
+      dateLines,
     };
     captionLayoutCache = { key: cacheKey, layout };
     return layout;
@@ -559,34 +627,115 @@ export class CanvasRenderer {
     ctx.shadowOffsetY = 0;
 
     const leftX = scaledX + layout.padding;
-    const rightX = leftX + layout.leftColumnWidth + layout.columnGap;
+    const rightEdgeX = scaledX + scaledWidth - layout.padding;
+    const dividerX =
+      leftX + layout.leftColumnWidth + Math.round(layout.columnGap / 2);
+    const contentTop = scaledY + (layout.height - layout.contentHeight) / 2;
 
     ctx.save();
-    ctx.textAlign = 'left';
     ctx.textBaseline = 'alphabetic';
 
-    // Title (camera make/model) on left column, vertically centered in the bar
+    // Hairline divider between columns
+    if (layout.contentHeight > 0) {
+      const lineWidth = Math.max(1, Math.round(scaleFactor));
+      ctx.save();
+      ctx.fillStyle = 'rgba(255, 255, 255, 0.18)';
+      ctx.fillRect(
+        Math.round(dividerX - lineWidth / 2),
+        contentTop,
+        lineWidth,
+        layout.contentHeight
+      );
+      ctx.restore();
+    }
+
+    // Left column: small-caps make + bold model, vertically centered
+    const makeBlockHeight = layout.makeText ? layout.makeFontSize : 0;
     const titleBlockHeight =
       layout.titleLines.length > 0
         ? layout.titleFontSize +
           (layout.titleLines.length - 1) * layout.titleLineHeight
         : 0;
-    const titleTop = scaledY + (layout.height - titleBlockHeight) / 2;
-    let leftY = titleTop + layout.titleFontSize;
-    const titleWeight = 600;
-    ctx.font = `${titleWeight} ${layout.titleFontSize}px ${style.fontFamily}`;
-    for (const line of layout.titleLines) {
-      ctx.fillText(line, leftX, leftY);
-      leftY += layout.titleLineHeight;
+    const leftBlockHeight =
+      makeBlockHeight +
+      (makeBlockHeight && titleBlockHeight ? layout.makeToTitleGap : 0) +
+      titleBlockHeight;
+    let leftY = contentTop + (layout.contentHeight - leftBlockHeight) / 2;
+
+    if (layout.makeText) {
+      ctx.save();
+      ctx.textAlign = 'left';
+      ctx.font = `${layout.makeFontSize}px ${style.fontFamily}`;
+      ctx.letterSpacing = layout.makeLetterSpacing;
+      ctx.fillText(layout.makeText, leftX, leftY + layout.makeFontSize);
+      ctx.restore();
+      leftY += layout.makeFontSize + layout.makeToTitleGap;
     }
 
-    // Right column body lines
-    if (layout.rightBodyLines.length > 0) {
-      let rightY = scaledY + layout.padding + layout.bodyFontSize;
-      ctx.font = `${layout.bodyFontSize}px ${style.fontFamily}`;
-      for (const line of layout.rightBodyLines) {
-        ctx.fillText(line, rightX, rightY);
-        rightY += layout.bodyLineHeight;
+    if (layout.titleLines.length > 0) {
+      ctx.save();
+      ctx.textAlign = 'left';
+      const titleWeight = 600;
+      ctx.font = `${titleWeight} ${layout.titleFontSize}px ${style.fontFamily}`;
+      let cursorY = leftY + layout.titleFontSize;
+      for (const line of layout.titleLines) {
+        ctx.fillText(line, leftX, cursorY);
+        cursorY += layout.titleLineHeight;
+      }
+      ctx.restore();
+    }
+
+    // Right column: params / date, right-aligned, vertically centered
+    const rightBlocks: Array<{ height: number; draw: (top: number) => void }> =
+      [];
+
+    if (layout.paramsLines.length > 0) {
+      rightBlocks.push({
+        height:
+          layout.paramsFontSize +
+          (layout.paramsLines.length - 1) * layout.paramsLineHeight,
+        draw: (top) => {
+          ctx.save();
+          ctx.textAlign = 'right';
+          ctx.font = `${layout.paramsFontSize}px ${style.fontFamily}`;
+          let cursorY = top + layout.paramsFontSize;
+          for (const line of layout.paramsLines) {
+            ctx.fillText(line, rightEdgeX, cursorY);
+            cursorY += layout.paramsLineHeight;
+          }
+          ctx.restore();
+        },
+      });
+    }
+
+    if (layout.dateLines.length > 0) {
+      rightBlocks.push({
+        height:
+          layout.metaFontSize +
+          (layout.dateLines.length - 1) * layout.metaLineHeight,
+        draw: (top) => {
+          ctx.save();
+          ctx.textAlign = 'right';
+          ctx.globalAlpha = 0.6;
+          ctx.font = `${layout.metaFontSize}px ${style.fontFamily}`;
+          let cursorY = top + layout.metaFontSize;
+          for (const line of layout.dateLines) {
+            ctx.fillText(line, rightEdgeX, cursorY);
+            cursorY += layout.metaLineHeight;
+          }
+          ctx.restore();
+        },
+      });
+    }
+
+    if (rightBlocks.length > 0) {
+      const totalRightHeight =
+        rightBlocks.reduce((sum, b) => sum + b.height, 0) +
+        (rightBlocks.length - 1) * layout.rightRowGap;
+      let rightTop = contentTop + (layout.contentHeight - totalRightHeight) / 2;
+      for (const block of rightBlocks) {
+        block.draw(rightTop);
+        rightTop += block.height + layout.rightRowGap;
       }
     }
 

--- a/src/services/exifExtractor.ts
+++ b/src/services/exifExtractor.ts
@@ -1,5 +1,6 @@
 import exifr from 'exifr';
 import type { ExifData, NormalizedExifData } from '@/types/exif';
+import { formatSonyModel } from './cameraNameFormatter';
 
 function calculateShutterSpeed(exposureTime?: number): string | undefined {
   if (!exposureTime) return undefined;
@@ -153,10 +154,16 @@ export async function extractExifData(file: File): Promise<ExifData> {
 }
 
 export function normalizeExifData(exifData: ExifData): NormalizedExifData {
+  const rawMake = exifData.camera?.make;
+  const friendlyModel = formatSonyModel(rawMake, exifData.camera?.model);
+
   return {
-    camera: formatCamera(exifData.camera),
-    cameraMake: formatStringField(exifData.camera?.make),
-    cameraModel: formatStringField(exifData.camera?.model),
+    camera: formatCamera({
+      make: rawMake,
+      model: friendlyModel ?? undefined,
+    }),
+    cameraMake: formatStringField(rawMake),
+    cameraModel: formatStringField(friendlyModel ?? undefined),
     lens: formatLens(exifData.lens),
     focalLength: formatFocalLength(exifData.lens?.focalLength),
     iso: formatISO(exifData.settings?.iso),

--- a/src/templates/caption.ts
+++ b/src/templates/caption.ts
@@ -13,7 +13,7 @@ export const captionTemplate: Template = {
     textColor: '#ffffff',
     backgroundColor: '#000000',
     opacity: 1,
-    padding: 18,
+    padding: 28,
     borderRadius: 0,
   },
   position: {


### PR DESCRIPTION
## Summary
- Caption template now leads with a small-caps make label and a single bold title combining camera model and lens, with a hairline divider separating the right column (inline shooting params + low-key date)
- Sony EXIF model codes (`ILCE-` / `ILCA-` / `DSC-`) are normalized in `normalizeExifData` so the displayed name reads `α1 II` instead of `ILCE-1M2` across every template, with a clean fallback to the raw string for unknown patterns
- Bumped caption padding `18 → 28`, introduced an independent `paramsFontSize` (1.15× body) and a larger `makeFontSize` (1.05× body) so the visual hierarchy reads title → params → make → body → meta

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test` (46 tests, including 25 new `cameraNameFormatter` cases and updated `exifExtractor` integration tests)
- [x] `npm run build`
- [ ] Visual check in `npm run dev` against a Sony α image to confirm:
  - α character renders correctly in Besley
  - title line stays on one row for typical model+lens combinations
  - hairline divider position looks balanced

🤖 Generated with [Claude Code](https://claude.com/claude-code)