### PR TITLE
feat(editor): add lens name override

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { ImageWorkspace } from '@/components/workspace/ImageWorkspace';
 import { TemplateSelector } from '@/components/editor/TemplateSelector';
+import { LensOverrideField } from '@/components/editor/LensOverrideField';
 import { ExportControls } from '@/components/export/ExportControls';
 import { ThemeToggle } from '@/components/ui/ThemeToggle';
 import { ToastContainer } from '@/components/ui/Toast';
@@ -41,6 +42,10 @@ export default function Home() {
           <div className="lg:col-span-1 space-y-6">
             <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6 transition-colors">
               <TemplateSelector />
+            </div>
+
+            <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6 transition-colors">
+              <LensOverrideField />
             </div>
 
             <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6 transition-colors">

--- a/src/components/editor/LensOverrideField.tsx
+++ b/src/components/editor/LensOverrideField.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import clsx from 'clsx';
+import { useSelectedImage } from '@/stores/imageStore';
+import { useExifStore } from '@/stores/exifStore';
+
+const DEBOUNCE_MS = 200;
+
+type OverrideState = 'exif' | 'custom' | 'hidden';
+
+function deriveState(override: string | null | undefined): OverrideState {
+  if (override === undefined) return 'exif';
+  if (override === null) return 'hidden';
+  return override.trim() ? 'custom' : 'hidden';
+}
+
+export function LensOverrideField() {
+  const selectedImage = useSelectedImage();
+  const imageId = selectedImage?.id;
+
+  const baseLens = useExifStore((state) =>
+    imageId ? (state.normalizedData[imageId]?.lens ?? null) : null
+  );
+  const override = useExifStore((state) =>
+    imageId ? state.lensOverrides[imageId] : undefined
+  );
+  const setLensOverride = useExifStore((state) => state.setLensOverride);
+  const clearLensOverride = useExifStore((state) => state.clearLensOverride);
+
+  const [inputValue, setInputValue] = useState('');
+  const [lastSyncedImageId, setLastSyncedImageId] = useState<
+    string | undefined
+  >(undefined);
+
+  if (imageId !== lastSyncedImageId) {
+    setLastSyncedImageId(imageId);
+    setInputValue(override === undefined || override === null ? '' : override);
+  }
+
+  useEffect(() => {
+    if (!imageId) return;
+    const handle = window.setTimeout(() => {
+      const trimmed = inputValue.trim();
+      if (!trimmed) {
+        if (override !== undefined && override !== null) {
+          clearLensOverride(imageId);
+        }
+        return;
+      }
+      if (override !== inputValue) {
+        setLensOverride(imageId, inputValue);
+      }
+    }, DEBOUNCE_MS);
+    return () => window.clearTimeout(handle);
+  }, [inputValue, imageId, override, setLensOverride, clearLensOverride]);
+
+  const state = deriveState(override);
+  const disabled = !imageId;
+
+  const handleResetToExif = () => {
+    if (!imageId) return;
+    setInputValue('');
+    clearLensOverride(imageId);
+  };
+
+  const handleHide = () => {
+    if (!imageId) return;
+    setInputValue('');
+    setLensOverride(imageId, null);
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">
+          Lens Override
+        </h3>
+        <span
+          className={clsx(
+            'text-xs font-medium px-2 py-0.5 rounded',
+            state === 'exif' &&
+              'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+            state === 'custom' &&
+              'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+            state === 'hidden' &&
+              'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'
+          )}
+        >
+          {state === 'exif' && 'EXIF'}
+          {state === 'custom' && 'Custom'}
+          {state === 'hidden' && 'Hidden'}
+        </span>
+      </div>
+
+      <input
+        type="text"
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value)}
+        disabled={disabled}
+        placeholder={baseLens ?? 'No lens info in EXIF'}
+        className={clsx(
+          'w-full px-3 py-2 rounded-md border text-sm transition-colors',
+          'border-gray-300 bg-white text-gray-900 placeholder:text-gray-400',
+          'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent',
+          'dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500',
+          disabled && 'opacity-50 cursor-not-allowed'
+        )}
+      />
+
+      <div className="flex gap-2 text-xs">
+        <button
+          type="button"
+          onClick={handleResetToExif}
+          disabled={disabled || state === 'exif'}
+          className={clsx(
+            'px-2 py-1 rounded text-gray-600 dark:text-gray-300',
+            'hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors',
+            'disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent'
+          )}
+        >
+          Reset to EXIF
+        </button>
+        <button
+          type="button"
+          onClick={handleHide}
+          disabled={disabled || state === 'hidden'}
+          className={clsx(
+            'px-2 py-1 rounded text-gray-600 dark:text-gray-300',
+            'hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors',
+            'disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent'
+          )}
+        >
+          Hide field
+        </button>
+      </div>
+
+      <p className="text-xs text-gray-500 dark:text-gray-400">
+        Override the lens name displayed on the overlay. Useful for old/manual
+        lenses without EXIF lens info.
+      </p>
+    </div>
+  );
+}

--- a/src/components/export/ExportControls.tsx
+++ b/src/components/export/ExportControls.tsx
@@ -16,7 +16,9 @@ export function ExportControls() {
   const toast = useToast();
 
   const selectedImage = useSelectedImage();
-  const getNormalizedData = useExifStore((state) => state.getNormalizedData);
+  const getEffectiveNormalizedData = useExifStore(
+    (state) => state.getEffectiveNormalizedData
+  );
   const selectedTemplate = useTemplateStore((state) => state.selectedTemplate);
   const canvasSettings = useSettingsStore((state) => state.canvasSettings);
   const updateCanvasSettings = useSettingsStore(
@@ -30,7 +32,7 @@ export function ExportControls() {
 
     try {
       const image = await ImageProcessor.createImageElement(selectedImage.url);
-      const exifData = getNormalizedData(selectedImage.id);
+      const exifData = getEffectiveNormalizedData(selectedImage.id);
 
       if (!exifData) {
         throw new Error('No EXIF data available');

--- a/src/hooks/useCanvasRenderer.ts
+++ b/src/hooks/useCanvasRenderer.ts
@@ -1,5 +1,4 @@
 import { useRef, useState, useEffect } from 'react';
-import { useExifStore } from '@/stores/exifStore';
 import { useTemplateStore } from '@/stores/templateStore';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { ImageProcessor } from '@/services/imageProcessor';
@@ -8,6 +7,7 @@ import type { NormalizedExifData } from '@/types/exif';
 import type { ProcessedImage } from '@/types/image';
 import type { Template } from '@/types/template';
 import { getDisplayBounds, useResponsiveCanvas } from './useResponsiveCanvas';
+import { useEffectiveExifData } from './useEffectiveExifData';
 
 // 2x oversample over the on-screen size: keeps a Retina-grade source
 // for the browser's CSS scaler while letting step-down do the heavy
@@ -79,9 +79,7 @@ export function useCanvasRenderer(currentImage: ProcessedImage | null) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [isRendering, setIsRendering] = useState(false);
 
-  const currentExifData = useExifStore((state) =>
-    currentImage?.id ? state.normalizedData[currentImage.id] : undefined
-  );
+  const currentExifData = useEffectiveExifData(currentImage?.id);
   const selectedTemplate = useTemplateStore((state) => state.selectedTemplate);
   const canvasSettings = useSettingsStore((state) => state.canvasSettings);
 

--- a/src/hooks/useEffectiveExifData.ts
+++ b/src/hooks/useEffectiveExifData.ts
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+import { useExifStore } from '@/stores/exifStore';
+import type { NormalizedExifData } from '@/types/exif';
+
+export function useEffectiveExifData(
+  imageId: string | undefined
+): NormalizedExifData | undefined {
+  const base = useExifStore((state) =>
+    imageId ? state.normalizedData[imageId] : undefined
+  );
+  const override = useExifStore((state) =>
+    imageId ? state.lensOverrides[imageId] : undefined
+  );
+
+  return useMemo(() => {
+    if (!base) return undefined;
+    if (override === undefined) return base;
+    const trimmed = typeof override === 'string' ? override.trim() : '';
+    return { ...base, lens: trimmed ? trimmed : null };
+  }, [base, override]);
+}

--- a/src/stores/__tests__/exifStore.test.ts
+++ b/src/stores/__tests__/exifStore.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useExifStore } from '../exifStore';
+import type { NormalizedExifData } from '@/types/exif';
+
+const baseNormalized: NormalizedExifData = {
+  camera: 'Sony α7 IV',
+  cameraMake: 'Sony',
+  cameraModel: 'α7 IV',
+  lens: 'Sony FE 24-70mm F2.8 GM',
+  focalLength: '50mm',
+  iso: 'ISO 100',
+  aperture: 'f/2.8',
+  shutterSpeed: '1/250s',
+  dateTime: '2024/06/15 14:30',
+};
+
+function reset() {
+  useExifStore.setState({
+    exifData: {},
+    normalizedData: {},
+    lensOverrides: {},
+  });
+}
+
+describe('exifStore lens overrides', () => {
+  beforeEach(reset);
+
+  it('returns base data when no override is set', () => {
+    const store = useExifStore.getState();
+    store.setNormalizedData('img-1', baseNormalized);
+
+    const effective = useExifStore
+      .getState()
+      .getEffectiveNormalizedData('img-1');
+    expect(effective).toEqual(baseNormalized);
+  });
+
+  it('replaces lens with a non-empty override string', () => {
+    const store = useExifStore.getState();
+    store.setNormalizedData('img-1', baseNormalized);
+    store.setLensOverride('img-1', 'Helios 44-2 58mm f/2');
+
+    const effective = useExifStore
+      .getState()
+      .getEffectiveNormalizedData('img-1');
+    expect(effective?.lens).toBe('Helios 44-2 58mm f/2');
+    expect(effective?.camera).toBe(baseNormalized.camera);
+    expect(effective?.focalLength).toBe(baseNormalized.focalLength);
+  });
+
+  it('treats null override as hidden (lens becomes null)', () => {
+    const store = useExifStore.getState();
+    store.setNormalizedData('img-1', baseNormalized);
+    store.setLensOverride('img-1', null);
+
+    const effective = useExifStore
+      .getState()
+      .getEffectiveNormalizedData('img-1');
+    expect(effective?.lens).toBeNull();
+  });
+
+  it('treats whitespace-only override as hidden', () => {
+    const store = useExifStore.getState();
+    store.setNormalizedData('img-1', baseNormalized);
+    store.setLensOverride('img-1', '   ');
+
+    const effective = useExifStore
+      .getState()
+      .getEffectiveNormalizedData('img-1');
+    expect(effective?.lens).toBeNull();
+  });
+
+  it('does not leak overrides between images', () => {
+    const store = useExifStore.getState();
+    store.setNormalizedData('img-1', baseNormalized);
+    store.setNormalizedData('img-2', baseNormalized);
+    store.setLensOverride('img-1', 'Helios 44-2');
+
+    const effective1 = useExifStore
+      .getState()
+      .getEffectiveNormalizedData('img-1');
+    const effective2 = useExifStore
+      .getState()
+      .getEffectiveNormalizedData('img-2');
+    expect(effective1?.lens).toBe('Helios 44-2');
+    expect(effective2?.lens).toBe(baseNormalized.lens);
+  });
+
+  it('clearLensOverride reverts to EXIF', () => {
+    const store = useExifStore.getState();
+    store.setNormalizedData('img-1', baseNormalized);
+    store.setLensOverride('img-1', 'Helios 44-2');
+    store.clearLensOverride('img-1');
+
+    const effective = useExifStore
+      .getState()
+      .getEffectiveNormalizedData('img-1');
+    expect(effective?.lens).toBe(baseNormalized.lens);
+  });
+
+  it('clearExifData removes the override for that image', () => {
+    const store = useExifStore.getState();
+    store.setNormalizedData('img-1', baseNormalized);
+    store.setLensOverride('img-1', 'Helios 44-2');
+    store.clearExifData('img-1');
+
+    expect(useExifStore.getState().lensOverrides['img-1']).toBeUndefined();
+    expect(
+      useExifStore.getState().getEffectiveNormalizedData('img-1')
+    ).toBeNull();
+  });
+
+  it('returns null when image has no normalized data', () => {
+    expect(
+      useExifStore.getState().getEffectiveNormalizedData('missing')
+    ).toBeNull();
+  });
+});

--- a/src/stores/exifStore.ts
+++ b/src/stores/exifStore.ts
@@ -4,16 +4,30 @@ import type { ExifData, NormalizedExifData } from '@/types/exif';
 interface ExifState {
   exifData: Record<string, ExifData>;
   normalizedData: Record<string, NormalizedExifData>;
+  lensOverrides: Record<string, string | null>;
   setExifData: (imageId: string, data: ExifData) => void;
   setNormalizedData: (imageId: string, data: NormalizedExifData) => void;
   getExifData: (imageId: string) => ExifData | null;
   getNormalizedData: (imageId: string) => NormalizedExifData | null;
+  getEffectiveNormalizedData: (imageId: string) => NormalizedExifData | null;
+  setLensOverride: (imageId: string, value: string | null) => void;
+  clearLensOverride: (imageId: string) => void;
   clearExifData: (imageId: string) => void;
+}
+
+function applyLensOverride(
+  base: NormalizedExifData,
+  override: string | null | undefined
+): NormalizedExifData {
+  if (override === undefined) return base;
+  const trimmed = typeof override === 'string' ? override.trim() : '';
+  return { ...base, lens: trimmed ? trimmed : null };
 }
 
 export const useExifStore = create<ExifState>((set, get) => ({
   exifData: {},
   normalizedData: {},
+  lensOverrides: {},
 
   setExifData: (imageId, data) =>
     set((state) => ({
@@ -29,12 +43,36 @@ export const useExifStore = create<ExifState>((set, get) => ({
 
   getNormalizedData: (imageId) => get().normalizedData[imageId] || null,
 
+  getEffectiveNormalizedData: (imageId) => {
+    const base = get().normalizedData[imageId];
+    if (!base) return null;
+    return applyLensOverride(base, get().lensOverrides[imageId]);
+  },
+
+  setLensOverride: (imageId, value) =>
+    set((state) => ({
+      lensOverrides: { ...state.lensOverrides, [imageId]: value },
+    })),
+
+  clearLensOverride: (imageId) =>
+    set((state) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { [imageId]: _removed, ...rest } = state.lensOverrides;
+      return { lensOverrides: rest };
+    }),
+
   clearExifData: (imageId) =>
     set((state) => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { [imageId]: _exif, ...restExif } = state.exifData;
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { [imageId]: _norm, ...restNorm } = state.normalizedData;
-      return { exifData: restExif, normalizedData: restNorm };
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { [imageId]: _override, ...restOverrides } = state.lensOverrides;
+      return {
+        exifData: restExif,
+        normalizedData: restNorm,
+        lensOverrides: restOverrides,
+      };
     }),
 }));


### PR DESCRIPTION
## Summary
- レンズ名を画像ごとに上書きできる UI を追加（EXIF にレンズ情報が無い／意図と違うケース、特にオールドレンズやマウントアダプタ経由の運用向け）
- override は `exifStore.lensOverrides` に `imageId` キーで保持し、`useEffectiveExifData` フック経由で preview と export 双方に反映
- 3 状態を 1 つのフィールドに集約: 空欄=EXIF / 入力値=Custom / `null`=Hidden（行ごと非表示）。画像差し替え時に `clearExifData` 経由で override も自動破棄

## Notes
- 永続化は今回スコープ外（画像 ID が揮発するため意味がない）
- `focalLength` は EXIF 値のまま残す設計。焦点距離まで含めたい場合は入力欄に直書きする想定
- `null` を「強制非表示」に割り当てた根拠は、`canvasRenderer` 既存規約（`lens: null` で行スキップ）に揃えるため

## Test plan
- [x] `npm run lint` / `npm run format:check` / `npx tsc --noEmit` / `npm test` / `npm run build` すべて green
- [x] `exifStore.test.ts` 8 ケース（base 通過 / 文字列上書き / `null` 非表示 / 空白扱い / 画像間混線なし / clearLensOverride / clearExifData 連動 / 不在 ID）
- [ ] `npm run dev` で実画像をロードして preview/export に反映されることを確認
- [ ] 入力中のプレビュー更新がカクつかないか（debounce 200ms）
- [ ] 別画像に切り替えた際に input が初期化されるか
- [ ] Hide 時に隣接フィールドのレイアウトが崩れないか（特に compact の 2×2 グリッド）

🤖 Generated with [Claude Code](https://claude.com/claude-code)