### PR TITLE
chore(workers): enable preview URLs for non-production builds

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,8 @@
 name = "metamark"
 compatibility_date = "2025-08-31"
 main = "src/worker.ts"
+workers_dev = false
+preview_urls = true
 
 [assets]
 directory = "dist"


### PR DESCRIPTION
## Summary
- `wrangler.toml` のトップレベルに `workers_dev = false` と `preview_urls = true` を追加
- これにより Cloudflare Workers Builds が非 main ブランチで実行する `wrangler versions upload` のプレビュー URL が安定して有効化される
- ダッシュボードでの Preview URLs トグルがデプロイのたびに無効化される問題の対処

## Background
Cloudflare Workers は `wrangler.toml` を真実のソースとして扱うため、ダッシュボードで Preview URLs を ON にしても、次の `wrangler deploy` / `wrangler versions upload` で設定ファイルの内容に上書きされて巻き戻ってしまう。設定ファイル側で明示することで永続化する。

なお `workers_dev = false` は本番 Worker の `*.workers.dev` サブドメイン公開を抑止する意図 (本番はカスタムドメイン `metamark.kiakiraki.dev` のみで公開)。`preview_urls = true` で Version ごとのプレビュー URL のみ有効にする。

## Test plan
- [ ] main マージ後、本番デプロイで `workers_dev = false` / `preview_urls = true` が反映されていることをダッシュボードで確認
- [ ] 後続の PR push で Workers Builds のログに `<version-id>-metamark.<account>.workers.dev` 形式のプレビュー URL が出力されることを確認
- [ ] そのプレビュー URL に実際にアクセスしてアプリが動作することを確認
- [ ] 本番カスタムドメイン (`metamark.kiakiraki.dev`) は引き続き正常稼働していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)