### PR TITLE
feat(templates): add caption color invert option

### DIFF
--- a/src/components/editor/TemplateSelector.tsx
+++ b/src/components/editor/TemplateSelector.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion';
 import { useTemplateStore } from '@/stores/templateStore';
+import { useSettingsStore } from '@/stores/settingsStore';
 import { templates } from '@/templates';
 import type { TemplatePreset } from '@/types/template';
 import { PositionSelector } from './PositionSelector';
@@ -10,6 +11,8 @@ import clsx from 'clsx';
 export function TemplateSelector() {
   const selectedTemplate = useTemplateStore((state) => state.selectedTemplate);
   const selectTemplate = useTemplateStore((state) => state.selectTemplate);
+  const captionInvert = useSettingsStore((state) => state.captionInvert);
+  const setCaptionInvert = useSettingsStore((state) => state.setCaptionInvert);
 
   const templatePresets: {
     key: TemplatePreset;
@@ -108,6 +111,42 @@ export function TemplateSelector() {
               visible
             </p>
           </div>
+        </div>
+      )}
+
+      {selectedTemplate?.customDraw === 'caption' && (
+        <div className="mt-4 p-3 bg-gray-50 dark:bg-gray-700 rounded-lg transition-colors">
+          <label className="flex items-center justify-between cursor-pointer">
+            <div className="space-y-0.5">
+              <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                Invert colors
+              </h4>
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                White background with black text
+              </p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={captionInvert}
+              onClick={() => setCaptionInvert(!captionInvert)}
+              className={clsx(
+                'relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors',
+                'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2',
+                'dark:focus:ring-offset-gray-700',
+                captionInvert
+                  ? 'bg-blue-600 dark:bg-blue-500'
+                  : 'bg-gray-300 dark:bg-gray-600'
+              )}
+            >
+              <span
+                className={clsx(
+                  'inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform',
+                  captionInvert ? 'translate-x-6' : 'translate-x-1'
+                )}
+              />
+            </button>
+          </label>
         </div>
       )}
 

--- a/src/components/export/ExportControls.tsx
+++ b/src/components/export/ExportControls.tsx
@@ -4,12 +4,12 @@ import { useState } from 'react';
 import { motion } from 'framer-motion';
 import { useSelectedImage } from '@/stores/imageStore';
 import { useExifStore } from '@/stores/exifStore';
-import { useTemplateStore } from '@/stores/templateStore';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { CanvasRenderer } from '@/services/canvasRenderer';
 import { ImageProcessor } from '@/services/imageProcessor';
 import clsx from 'clsx';
 import { useToast } from '@/hooks/useToast';
+import { useEffectiveTemplate } from '@/hooks/useEffectiveTemplate';
 
 export function ExportControls() {
   const [isExporting, setIsExporting] = useState(false);
@@ -19,7 +19,7 @@ export function ExportControls() {
   const getEffectiveNormalizedData = useExifStore(
     (state) => state.getEffectiveNormalizedData
   );
-  const selectedTemplate = useTemplateStore((state) => state.selectedTemplate);
+  const selectedTemplate = useEffectiveTemplate();
   const canvasSettings = useSettingsStore((state) => state.canvasSettings);
   const updateCanvasSettings = useSettingsStore(
     (state) => state.updateCanvasSettings

--- a/src/hooks/useCanvasRenderer.ts
+++ b/src/hooks/useCanvasRenderer.ts
@@ -1,5 +1,4 @@
 import { useRef, useState, useEffect } from 'react';
-import { useTemplateStore } from '@/stores/templateStore';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { ImageProcessor } from '@/services/imageProcessor';
 import { CanvasRenderer } from '@/services/canvasRenderer';
@@ -8,6 +7,7 @@ import type { ProcessedImage } from '@/types/image';
 import type { Template } from '@/types/template';
 import { getDisplayBounds, useResponsiveCanvas } from './useResponsiveCanvas';
 import { useEffectiveExifData } from './useEffectiveExifData';
+import { useEffectiveTemplate } from './useEffectiveTemplate';
 
 // 2x oversample over the on-screen size: keeps a Retina-grade source
 // for the browser's CSS scaler while letting step-down do the heavy
@@ -80,7 +80,7 @@ export function useCanvasRenderer(currentImage: ProcessedImage | null) {
   const [isRendering, setIsRendering] = useState(false);
 
   const currentExifData = useEffectiveExifData(currentImage?.id);
-  const selectedTemplate = useTemplateStore((state) => state.selectedTemplate);
+  const selectedTemplate = useEffectiveTemplate();
   const canvasSettings = useSettingsStore((state) => state.canvasSettings);
 
   const { containerHeight, updateCanvasDisplaySize } = useResponsiveCanvas(

--- a/src/hooks/useEffectiveTemplate.ts
+++ b/src/hooks/useEffectiveTemplate.ts
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+import { useTemplateStore } from '@/stores/templateStore';
+import { useSettingsStore } from '@/stores/settingsStore';
+import type { Template } from '@/types/template';
+
+export function useEffectiveTemplate(): Template | null {
+  const selectedTemplate = useTemplateStore((state) => state.selectedTemplate);
+  const captionInvert = useSettingsStore((state) => state.captionInvert);
+
+  return useMemo(() => {
+    if (!selectedTemplate) return null;
+    if (selectedTemplate.customDraw !== 'caption' || !captionInvert) {
+      return selectedTemplate;
+    }
+    return {
+      ...selectedTemplate,
+      style: {
+        ...selectedTemplate.style,
+        backgroundColor: '#ffffff',
+        textColor: '#000000',
+      },
+    };
+  }, [selectedTemplate, captionInvert]);
+}

--- a/src/services/canvasRenderer.ts
+++ b/src/services/canvasRenderer.ts
@@ -780,7 +780,8 @@ export class CanvasRenderer {
     if (layout.contentHeight > 0) {
       const lineWidth = Math.max(1, Math.round(scaleFactor));
       ctx.save();
-      ctx.fillStyle = 'rgba(255, 255, 255, 0.18)';
+      ctx.globalAlpha = 0.18;
+      ctx.fillStyle = style.textColor;
       ctx.fillRect(
         Math.round(dividerX - lineWidth / 2),
         contentTop,

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -4,7 +4,9 @@ import type { CanvasSettings } from '@/types/canvas';
 
 interface SettingsState {
   canvasSettings: CanvasSettings;
+  captionInvert: boolean;
   updateCanvasSettings: (settings: Partial<CanvasSettings>) => void;
+  setCaptionInvert: (value: boolean) => void;
   resetToDefaults: () => void;
 }
 
@@ -21,17 +23,24 @@ export const useSettingsStore = create<SettingsState>()(
   persist(
     (set) => ({
       canvasSettings: defaultCanvasSettings,
+      captionInvert: false,
 
       updateCanvasSettings: (settingsUpdate) =>
         set((state) => ({
           canvasSettings: { ...state.canvasSettings, ...settingsUpdate },
         })),
 
-      resetToDefaults: () => set({ canvasSettings: defaultCanvasSettings }),
+      setCaptionInvert: (value) => set({ captionInvert: value }),
+
+      resetToDefaults: () =>
+        set({ canvasSettings: defaultCanvasSettings, captionInvert: false }),
     }),
     {
       name: 'metamark-settings',
-      partialize: (state) => ({ canvasSettings: state.canvasSettings }),
+      partialize: (state) => ({
+        canvasSettings: state.canvasSettings,
+        captionInvert: state.captionInvert,
+      }),
     }
   )
 );


### PR DESCRIPTION
## Summary
- Caption テンプレートに白黒反転トグル (白背景 + 黒文字) を追加。`TemplateSelector` 内、Caption選択時にのみ表示
- 設定は `settingsStore.captionInvert` として localStorage に永続化
- カラム間のヘアライン罫線を `style.textColor` + `globalAlpha = 0.18` 由来に変更し、反転後も視認できるように
- 反転は `useEffectiveTemplate` という新規hookでテンプレートのstyleを差し替えて実現。レンダラ自体には反転の概念を持ち込んでいないので、`drawCaptionTemplate` は素直に `style.textColor` / `style.backgroundColor` を読むだけ
- 影響範囲: `useCanvasRenderer` / `useImageExport` / `ExportControls` を `useEffectiveTemplate` 経由に切り替え (プレビューとエクスポートで一致)

## Test plan
- [ ] Caption選択中、TemplateSelectorに "Invert colors" トグルが表示される
- [ ] 他テンプレート選択時はトグルが表示されない
- [ ] トグルONでプレビューが白背景+黒文字、OFFで黒背景+白文字
- [ ] エクスポート結果がプレビューと一致する
- [ ] リロード後も設定が保持されている (localStorage)
- [ ] 反転時にカラム間の縦罫線が見える
- [ ] CI: lint / format:check / tsc / test / build すべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)