### PR TITLE
feat(templates): remap Glass positions for direction consistency

### DIFF
--- a/src/services/canvasRenderer.ts
+++ b/src/services/canvasRenderer.ts
@@ -140,7 +140,10 @@ let technicalHorizontalLayoutCache: {
 function isTechnicalHorizontalPosition(
   position: PositionPreset | undefined
 ): boolean {
-  return position === 'top-left' || position === 'bottom-left';
+  // Glass template position mapping (each position name matches one corner the
+  // panel touches): top-left & bottom-right are horizontal banners (top/bottom
+  // edges); top-right & bottom-left are vertical panels (right/left edges).
+  return position === 'top-left' || position === 'bottom-right';
 }
 
 type CompactIconKind = 'camera' | 'lens-aperture';


### PR DESCRIPTION
## Summary

Glass テンプレートの Position 割り当てを、方角名と表示位置が矛盾しないように再マッピング。

| Position | 旧 | 新 |
|---|---|---|
| `top-left` ↖️ | 横長バナー・上 | 横長バナー・上（変更なし）|
| `top-right` ↗️ | 縦長パネル・右 | 縦長パネル・右（変更なし）|
| `bottom-left` ↙️ | 横長バナー・下 | **縦長パネル・左**（新規）|
| `bottom-right` ↘️ | 縦長パネル・右（重複）| **横長バナー・下** |

各 Position 名が、パネルが必ず接している角を指すようになり、TR↔BL が縦長、TL↔BR が横長で対角対称な配置に。

これまで `bottom-right` を選ぶと `top-right` と同じ縦長右パネルが描画されており、左側に縦長パネルを表示する手段がなかった問題を解消。

## Implementation

`canvasRenderer.ts` の `isTechnicalHorizontalPosition` ヘルパー関数の判定を `top-left | bottom-left` から `top-left | bottom-right` に変更するだけ。既存の x/y 計算が方角に対して対称な数式になっているため、ヘルパーの判定変更だけで両モードのアンカーが正しく切り替わる。

## Breaking changes

- 旧 `bottom-left`（横長バナー・下）を選んでいたユーザーは縦長パネル・左に変化
- 旧 `bottom-right`（縦長パネル・右）を選んでいたユーザーは横長バナー・下に変化

`overlayPosition` は `settingsStore` 経由でユーザー設定として保存されるが、移行ロジックは入れていない（破壊的変更を許容する方針）。

## Test plan

- [ ] Glass テンプレートを選択し、4つの Position それぞれで表示が以下になることを確認
  - [ ] `top-left` → 上端を全幅で覆う横長バナー
  - [ ] `top-right` → 右端を全高で覆う縦長パネル
  - [ ] `bottom-left` → 左端を全高で覆う縦長パネル（新規）
  - [ ] `bottom-right` → 下端を全幅で覆う横長バナー
- [ ] 横長 / 縦長の両方向で画像を読み込んでも崩れがないこと
- [ ] 他テンプレート（caption / compact / film）の Position 挙動に影響がないこと
- [x] `npx tsc --noEmit` パス
- [x] `npm run lint` パス
- [x] `npm test -- --run` 65 tests パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)