### PR TITLE
Add Location field across Caption, Glass, and Compact templates

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { ImageWorkspace } from '@/components/workspace/ImageWorkspace';
 import { TemplateSelector } from '@/components/editor/TemplateSelector';
 import { LensOverrideField } from '@/components/editor/LensOverrideField';
+import { LocationOverrideField } from '@/components/editor/LocationOverrideField';
 import { ExportControls } from '@/components/export/ExportControls';
 import { ThemeToggle } from '@/components/ui/ThemeToggle';
 import { ToastContainer } from '@/components/ui/Toast';
@@ -46,6 +47,10 @@ export default function Home() {
 
             <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6 transition-colors">
               <LensOverrideField />
+            </div>
+
+            <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6 transition-colors">
+              <LocationOverrideField />
             </div>
 
             <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6 transition-colors">

--- a/src/components/editor/LocationOverrideField.tsx
+++ b/src/components/editor/LocationOverrideField.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import clsx from 'clsx';
+import { useSelectedImage } from '@/stores/imageStore';
+import { useExifStore } from '@/stores/exifStore';
+
+const DEBOUNCE_MS = 200;
+
+type OverrideState = 'exif' | 'custom' | 'hidden';
+
+function deriveState(override: string | null | undefined): OverrideState {
+  if (override === undefined) return 'exif';
+  if (override === null) return 'hidden';
+  return override.trim() ? 'custom' : 'hidden';
+}
+
+export function LocationOverrideField() {
+  const selectedImage = useSelectedImage();
+  const imageId = selectedImage?.id;
+
+  const baseLocation = useExifStore((state) =>
+    imageId ? (state.normalizedData[imageId]?.location ?? null) : null
+  );
+  const override = useExifStore((state) =>
+    imageId ? state.locationOverrides[imageId] : undefined
+  );
+  const setLocationOverride = useExifStore(
+    (state) => state.setLocationOverride
+  );
+  const clearLocationOverride = useExifStore(
+    (state) => state.clearLocationOverride
+  );
+
+  const [inputValue, setInputValue] = useState('');
+  const [lastSyncedImageId, setLastSyncedImageId] = useState<
+    string | undefined
+  >(undefined);
+
+  if (imageId !== lastSyncedImageId) {
+    setLastSyncedImageId(imageId);
+    setInputValue(override === undefined || override === null ? '' : override);
+  }
+
+  useEffect(() => {
+    if (!imageId) return;
+    const handle = window.setTimeout(() => {
+      const trimmed = inputValue.trim();
+      if (!trimmed) {
+        if (override !== undefined && override !== null) {
+          clearLocationOverride(imageId);
+        }
+        return;
+      }
+      if (override !== inputValue) {
+        setLocationOverride(imageId, inputValue);
+      }
+    }, DEBOUNCE_MS);
+    return () => window.clearTimeout(handle);
+  }, [
+    inputValue,
+    imageId,
+    override,
+    setLocationOverride,
+    clearLocationOverride,
+  ]);
+
+  const state = deriveState(override);
+  const disabled = !imageId;
+
+  const handleResetToExif = () => {
+    if (!imageId) return;
+    setInputValue('');
+    clearLocationOverride(imageId);
+  };
+
+  const handleHide = () => {
+    if (!imageId) return;
+    setInputValue('');
+    setLocationOverride(imageId, null);
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">
+          Location
+        </h3>
+        <span
+          className={clsx(
+            'text-xs font-medium px-2 py-0.5 rounded',
+            state === 'exif' &&
+              'bg-gray-200 text-gray-700 dark:bg-gray-700 dark:text-gray-300',
+            state === 'custom' &&
+              'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+            state === 'hidden' &&
+              'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'
+          )}
+        >
+          {state === 'exif' && 'EXIF'}
+          {state === 'custom' && 'Custom'}
+          {state === 'hidden' && 'Hidden'}
+        </span>
+      </div>
+
+      <input
+        type="text"
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value)}
+        disabled={disabled}
+        placeholder={baseLocation ?? 'e.g. Tokyo, Asakusa'}
+        className={clsx(
+          'w-full px-3 py-2 rounded-md border text-sm transition-colors',
+          'border-gray-300 bg-white text-gray-900 placeholder:text-gray-400',
+          'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent',
+          'dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 dark:placeholder:text-gray-500',
+          disabled && 'opacity-50 cursor-not-allowed'
+        )}
+      />
+
+      <div className="flex gap-2 text-xs">
+        <button
+          type="button"
+          onClick={handleResetToExif}
+          disabled={disabled || state === 'exif'}
+          className={clsx(
+            'px-2 py-1 rounded text-gray-600 dark:text-gray-300',
+            'hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors',
+            'disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent'
+          )}
+        >
+          Reset to EXIF
+        </button>
+        <button
+          type="button"
+          onClick={handleHide}
+          disabled={disabled || state === 'hidden'}
+          className={clsx(
+            'px-2 py-1 rounded text-gray-600 dark:text-gray-300',
+            'hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors',
+            'disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent'
+          )}
+        >
+          Hide field
+        </button>
+      </div>
+
+      <p className="text-xs text-gray-500 dark:text-gray-400">
+        Add the place where the photo was taken. Shown on the Caption, Glass,
+        and Compact templates. Falls back to IPTC location tags if present.
+      </p>
+    </div>
+  );
+}

--- a/src/hooks/useCanvasRenderer.ts
+++ b/src/hooks/useCanvasRenderer.ts
@@ -73,6 +73,7 @@ const PLACEHOLDER_EXIF_DATA: NormalizedExifData = {
   shutterSpeed: 'Loading...',
   iso: 'Loading...',
   dateTime: 'Loading...',
+  location: 'Loading...',
 };
 
 export function useCanvasRenderer(currentImage: ProcessedImage | null) {

--- a/src/hooks/useEffectiveExifData.ts
+++ b/src/hooks/useEffectiveExifData.ts
@@ -2,20 +2,34 @@ import { useMemo } from 'react';
 import { useExifStore } from '@/stores/exifStore';
 import type { NormalizedExifData } from '@/types/exif';
 
+function applyStringOverride(
+  current: string | null,
+  override: string | null | undefined
+): string | null {
+  if (override === undefined) return current;
+  const trimmed = typeof override === 'string' ? override.trim() : '';
+  return trimmed ? trimmed : null;
+}
+
 export function useEffectiveExifData(
   imageId: string | undefined
 ): NormalizedExifData | undefined {
   const base = useExifStore((state) =>
     imageId ? state.normalizedData[imageId] : undefined
   );
-  const override = useExifStore((state) =>
+  const lensOverride = useExifStore((state) =>
     imageId ? state.lensOverrides[imageId] : undefined
+  );
+  const locationOverride = useExifStore((state) =>
+    imageId ? state.locationOverrides[imageId] : undefined
   );
 
   return useMemo(() => {
     if (!base) return undefined;
-    if (override === undefined) return base;
-    const trimmed = typeof override === 'string' ? override.trim() : '';
-    return { ...base, lens: trimmed ? trimmed : null };
-  }, [base, override]);
+    return {
+      ...base,
+      lens: applyStringOverride(base.lens, lensOverride),
+      location: applyStringOverride(base.location, locationOverride),
+    };
+  }, [base, lensOverride, locationOverride]);
 }

--- a/src/services/__tests__/exifExtractor.test.ts
+++ b/src/services/__tests__/exifExtractor.test.ts
@@ -54,6 +54,41 @@ describe('normalizeExifData', () => {
     expect(result.aperture).toBeNull();
     expect(result.shutterSpeed).toBeNull();
     expect(result.dateTime).toBeNull();
+    expect(result.location).toBeNull();
+  });
+
+  it('joins all IPTC location parts with commas', () => {
+    const result = normalizeExifData({
+      iptc: {
+        sublocation: 'Asakusa',
+        city: 'Taito',
+        provinceState: 'Tokyo',
+        country: 'Japan',
+      },
+    });
+
+    expect(result.location).toBe('Asakusa, Taito, Tokyo, Japan');
+  });
+
+  it('omits missing IPTC parts and trims whitespace', () => {
+    const result = normalizeExifData({
+      iptc: {
+        sublocation: '  ',
+        city: ' Kyoto ',
+        country: 'Japan',
+      },
+    });
+
+    expect(result.location).toBe('Kyoto, Japan');
+  });
+
+  it('returns null location when IPTC is empty', () => {
+    expect(normalizeExifData({ iptc: {} }).location).toBeNull();
+    expect(
+      normalizeExifData({
+        iptc: { city: '', country: '   ' },
+      }).location
+    ).toBeNull();
   });
 
   it('formats long exposure shutter speed', () => {

--- a/src/services/canvasRenderer.ts
+++ b/src/services/canvasRenderer.ts
@@ -53,6 +53,7 @@ interface CaptionLayout {
   titleLines: string[];
   paramsLines: string[];
   dateLines: string[];
+  locationLines: string[];
 }
 
 let captionLayoutCache: {
@@ -66,7 +67,8 @@ type TechnicalIconKind =
   | 'aperture'
   | 'shutter'
   | 'iso'
-  | 'date';
+  | 'date'
+  | 'location';
 
 interface TechnicalRow {
   kind: TechnicalIconKind;
@@ -117,9 +119,12 @@ interface TechnicalHorizontalLayout {
   dividerThickness: number;
   dividerToItemsGap: number;
   rows: TechnicalRow[];
+  gridRows: number;
+  gridCols: number;
   itemColumnGap: number;
   itemColumnWidth: number;
   itemRowHeight: number;
+  itemRowGap: number;
   iconRadius: number;
   iconStrokeWidth: number;
   iconToTextGap: number;
@@ -146,13 +151,14 @@ function isTechnicalHorizontalPosition(
   return position === 'top-left' || position === 'bottom-right';
 }
 
-type CompactIconKind = 'camera' | 'lens-aperture';
+type CompactIconKind = 'camera' | 'lens-aperture' | 'location';
 
 interface CompactLayout {
   panelHeight: number;
   padding: number;
   borderRadius: number;
   cellWidth: number;
+  fullRowWidth: number;
   columnGap: number;
   rowGap: number;
   rowHeight: number;
@@ -166,6 +172,7 @@ interface CompactLayout {
   lensValue: string;
   settingsValue: string;
   dateValue: string;
+  locationValue: string | null;
 }
 
 let compactLayoutCache: {
@@ -664,6 +671,11 @@ export class CanvasRenderer {
       ? this.wrapText(measureCtx, dateText, rightColumnWidth)
       : [];
 
+    const locationText = exifData.location ?? null;
+    const locationLines = locationText
+      ? this.wrapText(measureCtx, locationText, rightColumnWidth)
+      : [];
+
     const blockHeight = (
       lines: string[],
       fontSize: number,
@@ -691,9 +703,16 @@ export class CanvasRenderer {
       metaFontSize,
       metaLineHeight
     );
-    const rightBlocks = [paramsBlockHeight, dateBlockHeight].filter(
-      (h) => h > 0
+    const locationBlockHeight = blockHeight(
+      locationLines,
+      metaFontSize,
+      metaLineHeight
     );
+    const rightBlocks = [
+      paramsBlockHeight,
+      dateBlockHeight,
+      locationBlockHeight,
+    ].filter((h) => h > 0);
     const rightHeight =
       rightBlocks.reduce((sum, h) => sum + h, 0) +
       Math.max(0, rightBlocks.length - 1) * rightRowGap;
@@ -724,6 +743,7 @@ export class CanvasRenderer {
       titleLines,
       paramsLines,
       dateLines,
+      locationLines,
     };
     captionLayoutCache = { key: cacheKey, layout };
     return layout;
@@ -873,6 +893,26 @@ export class CanvasRenderer {
       });
     }
 
+    if (layout.locationLines.length > 0) {
+      rightBlocks.push({
+        height:
+          layout.metaFontSize +
+          (layout.locationLines.length - 1) * layout.metaLineHeight,
+        draw: (top) => {
+          ctx.save();
+          ctx.textAlign = 'right';
+          ctx.globalAlpha = 0.6;
+          ctx.font = `${layout.metaFontSize}px ${style.fontFamily}`;
+          let cursorY = top + layout.metaFontSize;
+          for (const line of layout.locationLines) {
+            ctx.fillText(line, rightEdgeX, cursorY);
+            cursorY += layout.metaLineHeight;
+          }
+          ctx.restore();
+        },
+      });
+    }
+
     if (rightBlocks.length > 0) {
       const totalRightHeight =
         rightBlocks.reduce((sum, b) => sum + b.height, 0) +
@@ -955,6 +995,13 @@ export class CanvasRenderer {
     }
     if (exifData.dateTime) {
       rows.push({ kind: 'date', label: 'Date', value: exifData.dateTime });
+    }
+    if (exifData.location) {
+      rows.push({
+        kind: 'location',
+        label: 'Location',
+        value: exifData.location,
+      });
     }
 
     const layout: TechnicalLayout = {
@@ -1055,13 +1102,25 @@ export class CanvasRenderer {
     if (exifData.dateTime) {
       rows.push({ kind: 'date', label: 'Date', value: exifData.dateTime });
     }
+    if (exifData.location) {
+      rows.push({
+        kind: 'location',
+        label: 'Location',
+        value: exifData.location,
+      });
+    }
 
     const innerWidth = Math.max(0, panelWidth - padding * 2);
-    const itemCount = Math.max(1, rows.length);
-    const totalGapWidth = (itemCount - 1) * itemColumnGap;
+    // Wrap to a 2-row grid once we exceed 4 items so each cell stays wide
+    // enough for values like the date and location to render without being
+    // truncated on narrow (portrait) panels.
+    const gridRows = rows.length > 4 ? 2 : 1;
+    const gridCols = Math.max(1, Math.ceil(rows.length / gridRows));
+    const itemRowGap = baseFontSize * 0.85;
+    const totalGapWidth = (gridCols - 1) * itemColumnGap;
     const itemColumnWidth = Math.max(
       0,
-      (innerWidth - totalGapWidth) / itemCount
+      (innerWidth - totalGapWidth) / gridCols
     );
 
     const valueMaxWidth = Math.max(
@@ -1106,8 +1165,10 @@ export class CanvasRenderer {
         ? headerToDividerGap + dividerThickness + dividerToItemsGap
         : 0;
 
-    const contentHeight =
-      headerHeight + dividerSpace + (rows.length ? itemRowHeight : 0);
+    const itemsTotalHeight = rows.length
+      ? gridRows * itemRowHeight + (gridRows - 1) * itemRowGap
+      : 0;
+    const contentHeight = headerHeight + dividerSpace + itemsTotalHeight;
     const totalHeight = padding * 2 + contentHeight;
 
     const layout: TechnicalHorizontalLayout = {
@@ -1125,9 +1186,12 @@ export class CanvasRenderer {
       dividerThickness,
       dividerToItemsGap,
       rows,
+      gridRows,
+      gridCols,
       itemColumnGap,
       itemColumnWidth,
       itemRowHeight,
+      itemRowGap,
       iconRadius,
       iconStrokeWidth,
       iconToTextGap,
@@ -1240,10 +1304,14 @@ export class CanvasRenderer {
 
     for (let i = 0; i < layout.rows.length; i++) {
       const row = layout.rows[i];
+      const col = i % layout.gridCols;
+      const gridRow = Math.floor(i / layout.gridCols);
       const cellX =
-        innerLeft + i * (layout.itemColumnWidth + layout.itemColumnGap);
+        innerLeft + col * (layout.itemColumnWidth + layout.itemColumnGap);
+      const cellTop =
+        itemRowTop + gridRow * (layout.itemRowHeight + layout.itemRowGap);
       const iconCx = cellX + layout.iconRadius;
-      const iconCy = itemRowTop + layout.itemRowHeight / 2;
+      const iconCy = cellTop + layout.itemRowHeight / 2;
 
       this.drawTechnicalIcon(
         ctx,
@@ -1263,7 +1331,7 @@ export class CanvasRenderer {
         layout.itemLabelFontSize +
         layout.itemLabelToValueGap +
         valueBlockHeight;
-      const textTop = itemRowTop + (layout.itemRowHeight - textBlockHeight) / 2;
+      const textTop = cellTop + (layout.itemRowHeight - textBlockHeight) / 2;
       const textX = cellX + layout.iconRadius * 2 + layout.iconToTextGap;
 
       ctx.save();
@@ -1504,6 +1572,29 @@ export class CanvasRenderer {
         ctx.stroke();
         break;
       }
+      case 'location': {
+        // Map pin: circular head joined to a downward tip via tangent lines.
+        const headR = r * 0.42;
+        const headCy = cy - r * 0.2;
+        const tipY = cy + r * 0.7;
+        const dy = tipY - headCy;
+        // Tangent points from external tip to head circle (symmetric about cx).
+        const ty = (headR * headR) / dy;
+        const tx = Math.sqrt(Math.max(0, headR * headR - ty * ty));
+        const angRight = Math.atan2(ty, tx);
+        const angLeft = Math.atan2(ty, -tx);
+        ctx.beginPath();
+        // Major arc of head circle from right tangent over the top to left tangent.
+        ctx.arc(cx, headCy, headR, angRight, angLeft, true);
+        ctx.lineTo(cx, tipY);
+        ctx.closePath();
+        ctx.stroke();
+        // Inner dot
+        ctx.beginPath();
+        ctx.arc(cx, headCy, Math.max(1, headR * 0.38), 0, Math.PI * 2);
+        ctx.fill();
+        break;
+      }
     }
 
     ctx.restore();
@@ -1719,7 +1810,13 @@ export class CanvasRenderer {
     const panelW = template.position.width * scaleFactor;
     const innerWidth = Math.max(0, panelW - padding * 2);
     const cellWidth = Math.max(0, (innerWidth - columnGap) / 2);
-    const panelHeight = padding * 2 + rowHeight * 2 + rowGap;
+    const fullRowWidth = innerWidth;
+    const locationValue = exifData.location ?? null;
+    const panelHeight =
+      padding * 2 +
+      rowHeight * 2 +
+      rowGap +
+      (locationValue ? rowHeight + rowGap : 0);
 
     const cameraValue = exifData.camera ?? '—';
     const lensValue = exifData.lens ?? '—';
@@ -1745,6 +1842,7 @@ export class CanvasRenderer {
       padding,
       borderRadius,
       cellWidth,
+      fullRowWidth,
       columnGap,
       rowGap,
       rowHeight,
@@ -1758,6 +1856,7 @@ export class CanvasRenderer {
       lensValue,
       settingsValue,
       dateValue,
+      locationValue,
     };
     compactLayoutCache = { key: cacheKey, layout };
     return layout;
@@ -1824,6 +1923,26 @@ export class CanvasRenderer {
           ctx.lineTo(cx + Math.cos(a) * r, cy + Math.sin(a) * r);
           ctx.stroke();
         }
+        break;
+      }
+      case 'location': {
+        // Map pin: matches the Glass template pin, scaled to compact size.
+        const headR = size * 0.21;
+        const headCy = cy - size * 0.1;
+        const tipY = cy + size * 0.35;
+        const dy = tipY - headCy;
+        const ty = (headR * headR) / dy;
+        const tx = Math.sqrt(Math.max(0, headR * headR - ty * ty));
+        const angRight = Math.atan2(ty, tx);
+        const angLeft = Math.atan2(ty, -tx);
+        ctx.beginPath();
+        ctx.arc(cx, headCy, headR, angRight, angLeft, true);
+        ctx.lineTo(cx, tipY);
+        ctx.closePath();
+        ctx.stroke();
+        ctx.beginPath();
+        ctx.arc(cx, headCy, Math.max(1, headR * 0.38), 0, Math.PI * 2);
+        ctx.fill();
         break;
       }
     }
@@ -1971,6 +2090,21 @@ export class CanvasRenderer {
       layout,
       style.fontFamily
     );
+
+    if (layout.locationValue) {
+      const row3Y = row2Y + layout.rowHeight + layout.rowGap;
+      this.drawCompactCell(
+        ctx,
+        col1X,
+        row3Y,
+        layout.fullRowWidth,
+        'LOCATION',
+        layout.locationValue,
+        'location',
+        layout,
+        style.fontFamily
+      );
+    }
 
     ctx.restore();
   }

--- a/src/services/exifExtractor.ts
+++ b/src/services/exifExtractor.ts
@@ -66,6 +66,20 @@ function formatShutterSpeed(
   return calculateShutterSpeed(exposureTime) || null;
 }
 
+function formatLocation(iptc?: {
+  sublocation?: string;
+  city?: string;
+  provinceState?: string;
+  country?: string;
+}): string | null {
+  if (!iptc) return null;
+  const parts = [iptc.sublocation, iptc.city, iptc.provinceState, iptc.country]
+    .map((part) => (typeof part === 'string' ? part.trim() : ''))
+    .filter((part) => part.length > 0);
+  if (parts.length === 0) return null;
+  return parts.join(', ');
+}
+
 function formatDateTime(dateTime?: string): string | null {
   if (!dateTime) return null;
 
@@ -146,6 +160,17 @@ export async function extractExifData(file: File): Promise<ExifData> {
               }
             : undefined,
       },
+      iptc: {
+        sublocation:
+          rawExif['Sub-location'] ?? rawExif.SubLocation ?? rawExif.Sublocation,
+        city: rawExif.City,
+        provinceState:
+          rawExif['Province-State'] ?? rawExif.ProvinceState ?? rawExif.State,
+        country:
+          rawExif['Country-PrimaryLocationName'] ??
+          rawExif.Country ??
+          rawExif.CountryPrimaryLocationName,
+      },
     };
   } catch (error: unknown) {
     console.error('Error extracting EXIF data:', error);
@@ -173,5 +198,6 @@ export function normalizeExifData(exifData: ExifData): NormalizedExifData {
       exifData.settings?.exposureTime
     ),
     dateTime: formatDateTime(exifData.metadata?.dateTime),
+    location: formatLocation(exifData.iptc),
   };
 }

--- a/src/stores/__tests__/exifStore.test.ts
+++ b/src/stores/__tests__/exifStore.test.ts
@@ -12,6 +12,7 @@ const baseNormalized: NormalizedExifData = {
   aperture: 'f/2.8',
   shutterSpeed: '1/250s',
   dateTime: '2024/06/15 14:30',
+  location: 'Kyoto, Japan',
 };
 
 function reset() {
@@ -19,6 +20,7 @@ function reset() {
     exifData: {},
     normalizedData: {},
     lensOverrides: {},
+    locationOverrides: {},
   });
 }
 
@@ -114,5 +116,103 @@ describe('exifStore lens overrides', () => {
     expect(
       useExifStore.getState().getEffectiveNormalizedData('missing')
     ).toBeNull();
+  });
+});
+
+describe('exifStore location overrides', () => {
+  beforeEach(reset);
+
+  it('returns base location when no override is set', () => {
+    const store = useExifStore.getState();
+    store.setNormalizedData('img-1', baseNormalized);
+
+    const effective = useExifStore
+      .getState()
+      .getEffectiveNormalizedData('img-1');
+    expect(effective?.location).toBe(baseNormalized.location);
+  });
+
+  it('replaces location with a non-empty override', () => {
+    const store = useExifStore.getState();
+    store.setNormalizedData('img-1', baseNormalized);
+    store.setLocationOverride('img-1', 'Tokyo, Asakusa');
+
+    const effective = useExifStore
+      .getState()
+      .getEffectiveNormalizedData('img-1');
+    expect(effective?.location).toBe('Tokyo, Asakusa');
+    expect(effective?.lens).toBe(baseNormalized.lens);
+  });
+
+  it('treats null override as hidden (location becomes null)', () => {
+    const store = useExifStore.getState();
+    store.setNormalizedData('img-1', baseNormalized);
+    store.setLocationOverride('img-1', null);
+
+    const effective = useExifStore
+      .getState()
+      .getEffectiveNormalizedData('img-1');
+    expect(effective?.location).toBeNull();
+  });
+
+  it('treats whitespace-only override as hidden', () => {
+    const store = useExifStore.getState();
+    store.setNormalizedData('img-1', baseNormalized);
+    store.setLocationOverride('img-1', '   ');
+
+    const effective = useExifStore
+      .getState()
+      .getEffectiveNormalizedData('img-1');
+    expect(effective?.location).toBeNull();
+  });
+
+  it('does not leak location overrides between images', () => {
+    const store = useExifStore.getState();
+    store.setNormalizedData('img-1', baseNormalized);
+    store.setNormalizedData('img-2', baseNormalized);
+    store.setLocationOverride('img-1', 'Tokyo');
+
+    const effective1 = useExifStore
+      .getState()
+      .getEffectiveNormalizedData('img-1');
+    const effective2 = useExifStore
+      .getState()
+      .getEffectiveNormalizedData('img-2');
+    expect(effective1?.location).toBe('Tokyo');
+    expect(effective2?.location).toBe(baseNormalized.location);
+  });
+
+  it('clearLocationOverride reverts to EXIF-derived value', () => {
+    const store = useExifStore.getState();
+    store.setNormalizedData('img-1', baseNormalized);
+    store.setLocationOverride('img-1', 'Tokyo');
+    store.clearLocationOverride('img-1');
+
+    const effective = useExifStore
+      .getState()
+      .getEffectiveNormalizedData('img-1');
+    expect(effective?.location).toBe(baseNormalized.location);
+  });
+
+  it('clearExifData removes the location override for that image', () => {
+    const store = useExifStore.getState();
+    store.setNormalizedData('img-1', baseNormalized);
+    store.setLocationOverride('img-1', 'Tokyo');
+    store.clearExifData('img-1');
+
+    expect(useExifStore.getState().locationOverrides['img-1']).toBeUndefined();
+  });
+
+  it('lens and location overrides apply independently', () => {
+    const store = useExifStore.getState();
+    store.setNormalizedData('img-1', baseNormalized);
+    store.setLensOverride('img-1', 'Helios 44-2');
+    store.setLocationOverride('img-1', 'Moscow');
+
+    const effective = useExifStore
+      .getState()
+      .getEffectiveNormalizedData('img-1');
+    expect(effective?.lens).toBe('Helios 44-2');
+    expect(effective?.location).toBe('Moscow');
   });
 });

--- a/src/stores/exifStore.ts
+++ b/src/stores/exifStore.ts
@@ -5,6 +5,7 @@ interface ExifState {
   exifData: Record<string, ExifData>;
   normalizedData: Record<string, NormalizedExifData>;
   lensOverrides: Record<string, string | null>;
+  locationOverrides: Record<string, string | null>;
   setExifData: (imageId: string, data: ExifData) => void;
   setNormalizedData: (imageId: string, data: NormalizedExifData) => void;
   getExifData: (imageId: string) => ExifData | null;
@@ -12,22 +13,25 @@ interface ExifState {
   getEffectiveNormalizedData: (imageId: string) => NormalizedExifData | null;
   setLensOverride: (imageId: string, value: string | null) => void;
   clearLensOverride: (imageId: string) => void;
+  setLocationOverride: (imageId: string, value: string | null) => void;
+  clearLocationOverride: (imageId: string) => void;
   clearExifData: (imageId: string) => void;
 }
 
-function applyLensOverride(
-  base: NormalizedExifData,
+function applyStringOverride(
+  current: string | null,
   override: string | null | undefined
-): NormalizedExifData {
-  if (override === undefined) return base;
+): string | null {
+  if (override === undefined) return current;
   const trimmed = typeof override === 'string' ? override.trim() : '';
-  return { ...base, lens: trimmed ? trimmed : null };
+  return trimmed ? trimmed : null;
 }
 
 export const useExifStore = create<ExifState>((set, get) => ({
   exifData: {},
   normalizedData: {},
   lensOverrides: {},
+  locationOverrides: {},
 
   setExifData: (imageId, data) =>
     set((state) => ({
@@ -46,7 +50,14 @@ export const useExifStore = create<ExifState>((set, get) => ({
   getEffectiveNormalizedData: (imageId) => {
     const base = get().normalizedData[imageId];
     if (!base) return null;
-    return applyLensOverride(base, get().lensOverrides[imageId]);
+    return {
+      ...base,
+      lens: applyStringOverride(base.lens, get().lensOverrides[imageId]),
+      location: applyStringOverride(
+        base.location,
+        get().locationOverrides[imageId]
+      ),
+    };
   },
 
   setLensOverride: (imageId, value) =>
@@ -61,6 +72,18 @@ export const useExifStore = create<ExifState>((set, get) => ({
       return { lensOverrides: rest };
     }),
 
+  setLocationOverride: (imageId, value) =>
+    set((state) => ({
+      locationOverrides: { ...state.locationOverrides, [imageId]: value },
+    })),
+
+  clearLocationOverride: (imageId) =>
+    set((state) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { [imageId]: _removed, ...rest } = state.locationOverrides;
+      return { locationOverrides: rest };
+    }),
+
   clearExifData: (imageId) =>
     set((state) => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -69,10 +92,14 @@ export const useExifStore = create<ExifState>((set, get) => ({
       const { [imageId]: _norm, ...restNorm } = state.normalizedData;
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { [imageId]: _override, ...restOverrides } = state.lensOverrides;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { [imageId]: _location, ...restLocationOverrides } =
+        state.locationOverrides;
       return {
         exifData: restExif,
         normalizedData: restNorm,
         lensOverrides: restOverrides,
+        locationOverrides: restLocationOverrides,
       };
     }),
 }));

--- a/src/types/exif.ts
+++ b/src/types/exif.ts
@@ -21,6 +21,12 @@ export interface ExifData {
       longitude?: number;
     };
   };
+  iptc?: {
+    sublocation?: string;
+    city?: string;
+    provinceState?: string;
+    country?: string;
+  };
 }
 
 export interface NormalizedExifData {
@@ -33,4 +39,5 @@ export interface NormalizedExifData {
   aperture: string | null;
   shutterSpeed: string | null;
   dateTime: string | null;
+  location: string | null;
 }


### PR DESCRIPTION
## Summary
- Adds a Location field to the EXIF data model with manual override and IPTC fallback (Sub-location / City / Province-State / Country joined by commas).
- Renders Location on three templates: Caption (right column under date), Glass (new map-pin icon row), Compact (full-width row appended only when Location is set).
- New `LocationOverrideField` UI in the sidebar, mirroring `LensOverrideField` (EXIF / Custom / Hidden states, debounce, reset/hide buttons).
- Glass horizontal layout switches to a 2-row grid when items exceed 4 (gridCols = ceil(items / 2)) so the extra row does not crush Date or Location on portrait photos.
- Reverse-geocoding is intentionally out of scope for this PR; the manual + IPTC path is the MVP.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test` — 76 passing (added 11 cases: 4 for `normalizeExifData` location, 7 for `exifStore` location override + cross-override independence)
- [x] `npm run build`
- [ ] Manual: load a photo with IPTC location tags → confirm auto-fill on each of the three templates
- [ ] Manual: enter a custom location → confirm override behavior + reset/hide buttons
- [ ] Manual: portrait photo + Glass Bottom Right → confirm 2-row grid prevents truncation
- [ ] Manual: Compact panel grows by one row only when Location is set (no regression for photos without Location)

🤖 Generated with [Claude Code](https://claude.com/claude-code)