### PR TITLE
feat(templates): add Imprint template

### DIFF
--- a/src/components/editor/TemplateSelector.tsx
+++ b/src/components/editor/TemplateSelector.tsx
@@ -117,51 +117,39 @@ export function TemplateSelector() {
 
       {selectedTemplate?.customDraw === 'imprint' && (
         <div className="mt-4 p-3 bg-gray-50 dark:bg-gray-700 rounded-lg transition-colors">
-          <div className="space-y-2">
+          <label className="flex items-center justify-between cursor-pointer">
             <div className="space-y-0.5">
               <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                Text color
+                Invert text color
               </h4>
               <p className="text-xs text-gray-500 dark:text-gray-400">
-                Pick the color that reads best against your photo
+                Black text instead of white
               </p>
             </div>
-            <div
-              role="radiogroup"
-              aria-label="Imprint text color"
-              className="grid grid-cols-2 gap-2"
+            <button
+              type="button"
+              role="switch"
+              aria-checked={imprintColor === 'black'}
+              onClick={() =>
+                setImprintColor(imprintColor === 'black' ? 'white' : 'black')
+              }
+              className={clsx(
+                'relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors',
+                'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2',
+                'dark:focus:ring-offset-gray-700',
+                imprintColor === 'black'
+                  ? 'bg-blue-600 dark:bg-blue-500'
+                  : 'bg-gray-300 dark:bg-gray-600'
+              )}
             >
-              {(['white', 'black'] as const).map((value) => {
-                const isActive = imprintColor === value;
-                return (
-                  <button
-                    key={value}
-                    type="button"
-                    role="radio"
-                    aria-checked={isActive}
-                    onClick={() => setImprintColor(value)}
-                    className={clsx(
-                      'flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-medium transition-colors',
-                      'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-700',
-                      isActive
-                        ? 'border-blue-500 bg-blue-50 text-blue-700 dark:border-blue-400 dark:bg-blue-900/30 dark:text-blue-200'
-                        : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700'
-                    )}
-                  >
-                    <span
-                      className={clsx(
-                        'h-3 w-3 rounded-full border',
-                        value === 'white'
-                          ? 'bg-white border-gray-300'
-                          : 'bg-black border-gray-700'
-                      )}
-                    />
-                    {value === 'white' ? 'White' : 'Black'}
-                  </button>
-                );
-              })}
-            </div>
-          </div>
+              <span
+                className={clsx(
+                  'inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform',
+                  imprintColor === 'black' ? 'translate-x-6' : 'translate-x-1'
+                )}
+              />
+            </button>
+          </label>
         </div>
       )}
 

--- a/src/components/editor/TemplateSelector.tsx
+++ b/src/components/editor/TemplateSelector.tsx
@@ -13,6 +13,8 @@ export function TemplateSelector() {
   const selectTemplate = useTemplateStore((state) => state.selectTemplate);
   const captionInvert = useSettingsStore((state) => state.captionInvert);
   const setCaptionInvert = useSettingsStore((state) => state.setCaptionInvert);
+  const imprintColor = useSettingsStore((state) => state.imprintColor);
+  const setImprintColor = useSettingsStore((state) => state.setImprintColor);
 
   const templatePresets: {
     key: TemplatePreset;
@@ -22,6 +24,7 @@ export function TemplateSelector() {
     { key: 'caption', name: 'Caption', description: 'Black footer bar' },
     { key: 'compact', name: 'Compact', description: '2×2 frosted info card' },
     { key: 'technical', name: 'Glass', description: 'Frosted glass card' },
+    { key: 'imprint', name: 'Imprint', description: 'Frameless text on photo' },
     { key: 'film', name: 'Film', description: 'Vintage style' },
   ];
 
@@ -108,6 +111,56 @@ export function TemplateSelector() {
               Fields: {selectedTemplate.fields.filter((f) => f.visible).length}{' '}
               visible
             </p>
+          </div>
+        </div>
+      )}
+
+      {selectedTemplate?.customDraw === 'imprint' && (
+        <div className="mt-4 p-3 bg-gray-50 dark:bg-gray-700 rounded-lg transition-colors">
+          <div className="space-y-2">
+            <div className="space-y-0.5">
+              <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                Text color
+              </h4>
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                Pick the color that reads best against your photo
+              </p>
+            </div>
+            <div
+              role="radiogroup"
+              aria-label="Imprint text color"
+              className="grid grid-cols-2 gap-2"
+            >
+              {(['white', 'black'] as const).map((value) => {
+                const isActive = imprintColor === value;
+                return (
+                  <button
+                    key={value}
+                    type="button"
+                    role="radio"
+                    aria-checked={isActive}
+                    onClick={() => setImprintColor(value)}
+                    className={clsx(
+                      'flex items-center justify-center gap-2 rounded-md border px-3 py-2 text-sm font-medium transition-colors',
+                      'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-700',
+                      isActive
+                        ? 'border-blue-500 bg-blue-50 text-blue-700 dark:border-blue-400 dark:bg-blue-900/30 dark:text-blue-200'
+                        : 'border-gray-200 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700'
+                    )}
+                  >
+                    <span
+                      className={clsx(
+                        'h-3 w-3 rounded-full border',
+                        value === 'white'
+                          ? 'bg-white border-gray-300'
+                          : 'bg-black border-gray-700'
+                      )}
+                    />
+                    {value === 'white' ? 'White' : 'Black'}
+                  </button>
+                );
+              })}
+            </div>
           </div>
         </div>
       )}

--- a/src/hooks/useEffectiveTemplate.ts
+++ b/src/hooks/useEffectiveTemplate.ts
@@ -6,19 +6,32 @@ import type { Template } from '@/types/template';
 export function useEffectiveTemplate(): Template | null {
   const selectedTemplate = useTemplateStore((state) => state.selectedTemplate);
   const captionInvert = useSettingsStore((state) => state.captionInvert);
+  const imprintColor = useSettingsStore((state) => state.imprintColor);
 
   return useMemo(() => {
     if (!selectedTemplate) return null;
-    if (selectedTemplate.customDraw !== 'caption' || !captionInvert) {
-      return selectedTemplate;
+
+    if (selectedTemplate.customDraw === 'caption' && captionInvert) {
+      return {
+        ...selectedTemplate,
+        style: {
+          ...selectedTemplate.style,
+          backgroundColor: '#ffffff',
+          textColor: '#000000',
+        },
+      };
     }
-    return {
-      ...selectedTemplate,
-      style: {
-        ...selectedTemplate.style,
-        backgroundColor: '#ffffff',
-        textColor: '#000000',
-      },
-    };
-  }, [selectedTemplate, captionInvert]);
+
+    if (selectedTemplate.customDraw === 'imprint') {
+      return {
+        ...selectedTemplate,
+        style: {
+          ...selectedTemplate.style,
+          textColor: imprintColor === 'black' ? '#000000' : '#ffffff',
+        },
+      };
+    }
+
+    return selectedTemplate;
+  }, [selectedTemplate, captionInvert, imprintColor]);
 }

--- a/src/services/canvasRenderer.ts
+++ b/src/services/canvasRenderer.ts
@@ -194,6 +194,9 @@ interface ImprintLayout {
   headlineGap: number;
   headlineHeight: number;
   makeLetterSpacing: string;
+  lensText: string | null;
+  lensFontSize: number;
+  lensOpacity: number;
   paramsText: string | null;
   paramsFontSize: number;
   paramsOpacity: number;
@@ -2159,6 +2162,7 @@ export class CanvasRenderer {
     const headlineGap = headlineFontSize * 0.3;
     const makeLetterSpacing = '0.04em';
 
+    const lensFontSize = Math.max(12, baseFontSize * 1.1);
     const paramsFontSize = Math.max(11, baseFontSize * 0.95);
     const locationFontSize = Math.max(11, baseFontSize * 0.82);
     const rowGap = baseFontSize * 0.5;
@@ -2182,10 +2186,12 @@ export class CanvasRenderer {
     ].filter((value): value is string => !!value);
     const paramsText = paramsParts.length > 0 ? paramsParts.join(' · ') : null;
 
+    const lensText = exifData.lens ?? null;
     const locationText = exifData.location ?? null;
 
     const blocks: number[] = [];
     if (makeText || modelText) blocks.push(headlineHeight);
+    if (lensText) blocks.push(lensFontSize);
     if (paramsText) blocks.push(paramsFontSize);
     if (locationText) blocks.push(locationFontSize);
     const contentHeight =
@@ -2206,6 +2212,9 @@ export class CanvasRenderer {
       headlineGap,
       headlineHeight,
       makeLetterSpacing,
+      lensText,
+      lensFontSize,
+      lensOpacity: 1,
       paramsText,
       paramsFontSize,
       paramsOpacity: 0.92,
@@ -2324,6 +2333,16 @@ export class CanvasRenderer {
       }
 
       cursorY += layout.headlineHeight + layout.rowGap;
+    }
+
+    if (layout.lensText) {
+      const baselineY = cursorY + layout.lensFontSize;
+      ctx.save();
+      ctx.globalAlpha = layout.lensOpacity;
+      ctx.font = `${layout.lensFontSize}px ${style.fontFamily}`;
+      ctx.fillText(layout.lensText, anchorX, baselineY);
+      ctx.restore();
+      cursorY += layout.lensFontSize + layout.rowGap;
     }
 
     if (layout.paramsText) {

--- a/src/services/canvasRenderer.ts
+++ b/src/services/canvasRenderer.ts
@@ -180,6 +180,33 @@ let compactLayoutCache: {
   layout: CompactLayout;
 } | null = null;
 
+interface ImprintLayout {
+  padding: number;
+  height: number;
+  contentHeight: number;
+  rowGap: number;
+  baseFontSize: number;
+  makeText: string | null;
+  modelText: string | null;
+  headlineFontSize: number;
+  headlineWeightMake: number;
+  headlineWeightModel: number;
+  headlineGap: number;
+  headlineHeight: number;
+  makeLetterSpacing: string;
+  paramsText: string | null;
+  paramsFontSize: number;
+  paramsOpacity: number;
+  locationText: string | null;
+  locationFontSize: number;
+  locationOpacity: number;
+}
+
+let imprintLayoutCache: {
+  key: string;
+  layout: ImprintLayout;
+} | null = null;
+
 export class CanvasRenderer {
   static async render(options: RenderOptions): Promise<string> {
     const { canvas, image, template, exifData, settings } = options;
@@ -496,6 +523,11 @@ export class CanvasRenderer {
     if (template.customDraw === 'compact') {
       const layout = this.buildCompactLayout(template, exifData, scaleFactor);
       return layout.panelHeight;
+    }
+
+    if (template.customDraw === 'imprint') {
+      const layout = this.buildImprintLayout(template, exifData, scaleFactor);
+      return layout.height;
     }
 
     tempCtx.font = `${scaledFontSize}px ${template.style.fontFamily}`;
@@ -2109,6 +2141,232 @@ export class CanvasRenderer {
     ctx.restore();
   }
 
+  private static buildImprintLayout(
+    template: Template,
+    exifData: NormalizedExifData,
+    scaleFactor: number
+  ): ImprintLayout {
+    const cacheKey = JSON.stringify(['imprint', scaleFactor, exifData]);
+    if (imprintLayoutCache?.key === cacheKey) {
+      return imprintLayoutCache.layout;
+    }
+
+    const padding = template.style.padding * scaleFactor;
+    const baseFontSize = Math.max(12, template.style.fontSize * scaleFactor);
+
+    const headlineFontSize = Math.max(18, baseFontSize * 1.5);
+    const headlineHeight = headlineFontSize;
+    const headlineGap = headlineFontSize * 0.3;
+    const makeLetterSpacing = '0.04em';
+
+    const paramsFontSize = Math.max(11, baseFontSize * 0.95);
+    const locationFontSize = Math.max(11, baseFontSize * 0.82);
+    const rowGap = baseFontSize * 0.5;
+
+    const { make, model } = this.getCaptionCameraParts(exifData);
+    const makeText = make ? make.toUpperCase() : null;
+    const modelText = model;
+
+    const apertureText = exifData.aperture
+      ? exifData.aperture.replace(/^f\//i, 'ƒ/')
+      : null;
+    const dateText = exifData.dateTime
+      ? exifData.dateTime.replace(/\//g, '.')
+      : null;
+    const paramsParts = [
+      dateText,
+      apertureText,
+      exifData.shutterSpeed,
+      exifData.iso,
+      exifData.focalLength,
+    ].filter((value): value is string => !!value);
+    const paramsText = paramsParts.length > 0 ? paramsParts.join(' · ') : null;
+
+    const locationText = exifData.location ?? null;
+
+    const blocks: number[] = [];
+    if (makeText || modelText) blocks.push(headlineHeight);
+    if (paramsText) blocks.push(paramsFontSize);
+    if (locationText) blocks.push(locationFontSize);
+    const contentHeight =
+      blocks.reduce((sum, h) => sum + h, 0) +
+      Math.max(0, blocks.length - 1) * rowGap;
+
+    const layout: ImprintLayout = {
+      padding,
+      height: padding + contentHeight + padding,
+      contentHeight,
+      rowGap,
+      baseFontSize,
+      makeText,
+      modelText,
+      headlineFontSize,
+      headlineWeightMake: 600,
+      headlineWeightModel: 400,
+      headlineGap,
+      headlineHeight,
+      makeLetterSpacing,
+      paramsText,
+      paramsFontSize,
+      paramsOpacity: 0.92,
+      locationText,
+      locationFontSize,
+      locationOpacity: 0.78,
+    };
+    imprintLayoutCache = { key: cacheKey, layout };
+    return layout;
+  }
+
+  private static drawImprintTemplate(
+    ctx: CanvasRenderingContext2D,
+    template: Template,
+    exifData: NormalizedExifData,
+    scaleFactor: number,
+    overlayPosition?: PositionPreset
+  ): void {
+    const { style, position } = template;
+    const scaledX = position.x;
+    const scaledY = position.y;
+    const scaledWidth = position.width * scaleFactor;
+
+    const layout = this.buildImprintLayout(template, exifData, scaleFactor);
+
+    const isRight =
+      overlayPosition === 'top-right' || overlayPosition === 'bottom-right';
+    const textAlign: CanvasTextAlign = isRight ? 'right' : 'left';
+    const anchorX = isRight
+      ? scaledX + scaledWidth - layout.padding
+      : scaledX + layout.padding;
+
+    // Shadow that contrasts with text color so the text reads on bright or dark photos.
+    const isLight = this.isLightTextColor(style.textColor);
+    const shadowColor = isLight
+      ? 'rgba(0, 0, 0, 0.7)'
+      : 'rgba(255, 255, 255, 0.75)';
+
+    ctx.save();
+    ctx.fillStyle = style.textColor;
+    ctx.textBaseline = 'alphabetic';
+    ctx.textAlign = textAlign;
+    ctx.shadowColor = shadowColor;
+    ctx.shadowBlur = Math.max(4, 6 * scaleFactor);
+    ctx.shadowOffsetX = 0;
+    ctx.shadowOffsetY = 0;
+
+    let cursorY = scaledY + layout.padding;
+
+    if (layout.makeText || layout.modelText) {
+      const baselineY = cursorY + layout.headlineHeight;
+      const makePart = layout.makeText ?? '';
+      const modelPart = layout.modelText ?? '';
+      const makeFont = `${layout.headlineWeightMake} ${layout.headlineFontSize}px ${style.fontFamily}`;
+      const modelFont = `${layout.headlineWeightModel} ${layout.headlineFontSize}px ${style.fontFamily}`;
+
+      const measureWidth = (
+        text: string,
+        font: string,
+        letterSpacing?: string
+      ): number => {
+        ctx.save();
+        ctx.font = font;
+        if (letterSpacing) {
+          (
+            ctx as CanvasRenderingContext2D & { letterSpacing?: string }
+          ).letterSpacing = letterSpacing;
+        }
+        const width = ctx.measureText(text).width;
+        ctx.restore();
+        return width;
+      };
+
+      if (textAlign === 'left') {
+        let x = anchorX;
+        if (makePart) {
+          ctx.save();
+          ctx.font = makeFont;
+          (
+            ctx as CanvasRenderingContext2D & { letterSpacing?: string }
+          ).letterSpacing = layout.makeLetterSpacing;
+          ctx.fillText(makePart, x, baselineY);
+          ctx.restore();
+          const makeWidth = measureWidth(
+            makePart,
+            makeFont,
+            layout.makeLetterSpacing
+          );
+          x += makeWidth + (modelPart ? layout.headlineGap : 0);
+        }
+        if (modelPart) {
+          ctx.save();
+          ctx.font = modelFont;
+          ctx.fillText(modelPart, x, baselineY);
+          ctx.restore();
+        }
+      } else {
+        let x = anchorX;
+        if (modelPart) {
+          ctx.save();
+          ctx.font = modelFont;
+          ctx.fillText(modelPart, x, baselineY);
+          ctx.restore();
+          const modelWidth = measureWidth(modelPart, modelFont);
+          x -= modelWidth + (makePart ? layout.headlineGap : 0);
+        }
+        if (makePart) {
+          ctx.save();
+          ctx.font = makeFont;
+          (
+            ctx as CanvasRenderingContext2D & { letterSpacing?: string }
+          ).letterSpacing = layout.makeLetterSpacing;
+          ctx.fillText(makePart, x, baselineY);
+          ctx.restore();
+        }
+      }
+
+      cursorY += layout.headlineHeight + layout.rowGap;
+    }
+
+    if (layout.paramsText) {
+      const baselineY = cursorY + layout.paramsFontSize;
+      ctx.save();
+      ctx.globalAlpha = layout.paramsOpacity;
+      ctx.font = `${layout.paramsFontSize}px ${style.fontFamily}`;
+      ctx.fillText(layout.paramsText, anchorX, baselineY);
+      ctx.restore();
+      cursorY += layout.paramsFontSize + layout.rowGap;
+    }
+
+    if (layout.locationText) {
+      const baselineY = cursorY + layout.locationFontSize;
+      ctx.save();
+      ctx.globalAlpha = layout.locationOpacity;
+      ctx.font = `${layout.locationFontSize}px ${style.fontFamily}`;
+      ctx.fillText(layout.locationText, anchorX, baselineY);
+      ctx.restore();
+    }
+
+    ctx.restore();
+  }
+
+  // Heuristic: treat #fff/white as "light", everything else as dark.
+  // Used to pick a contrasting drop shadow for the imprint text.
+  private static isLightTextColor(color: string): boolean {
+    const trimmed = color.trim().toLowerCase();
+    if (trimmed === '#ffffff' || trimmed === '#fff' || trimmed === 'white') {
+      return true;
+    }
+    const hex = trimmed.match(/^#([0-9a-f]{6})$/);
+    if (hex) {
+      const value = parseInt(hex[1], 16);
+      const r = (value >> 16) & 0xff;
+      const g = (value >> 8) & 0xff;
+      const b = value & 0xff;
+      const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+      return luminance > 0.6;
+    }
+    return false;
+  }
+
   private static drawTemplate(
     ctx: CanvasRenderingContext2D,
     template: Template,
@@ -2142,6 +2400,17 @@ export class CanvasRenderer {
 
     if (template.customDraw === 'compact') {
       this.drawCompactTemplate(ctx, template, exifData, scaleFactor);
+      return;
+    }
+
+    if (template.customDraw === 'imprint') {
+      this.drawImprintTemplate(
+        ctx,
+        template,
+        exifData,
+        scaleFactor,
+        options?.overlayPosition
+      );
       return;
     }
 

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -2,11 +2,15 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import type { CanvasSettings } from '@/types/canvas';
 
+export type ImprintColor = 'white' | 'black';
+
 interface SettingsState {
   canvasSettings: CanvasSettings;
   captionInvert: boolean;
+  imprintColor: ImprintColor;
   updateCanvasSettings: (settings: Partial<CanvasSettings>) => void;
   setCaptionInvert: (value: boolean) => void;
+  setImprintColor: (value: ImprintColor) => void;
   resetToDefaults: () => void;
 }
 
@@ -24,6 +28,7 @@ export const useSettingsStore = create<SettingsState>()(
     (set) => ({
       canvasSettings: defaultCanvasSettings,
       captionInvert: false,
+      imprintColor: 'white',
 
       updateCanvasSettings: (settingsUpdate) =>
         set((state) => ({
@@ -32,14 +37,21 @@ export const useSettingsStore = create<SettingsState>()(
 
       setCaptionInvert: (value) => set({ captionInvert: value }),
 
+      setImprintColor: (value) => set({ imprintColor: value }),
+
       resetToDefaults: () =>
-        set({ canvasSettings: defaultCanvasSettings, captionInvert: false }),
+        set({
+          canvasSettings: defaultCanvasSettings,
+          captionInvert: false,
+          imprintColor: 'white',
+        }),
     }),
     {
       name: 'metamark-settings',
       partialize: (state) => ({
         canvasSettings: state.canvasSettings,
         captionInvert: state.captionInvert,
+        imprintColor: state.imprintColor,
       }),
     }
   )

--- a/src/templates/imprint.ts
+++ b/src/templates/imprint.ts
@@ -1,0 +1,31 @@
+import type { Template } from '@/types/template';
+import { createStandardFields } from './shared/baseFields';
+import { geistSans } from '@/styles/fonts';
+
+export const imprintTemplate: Template = {
+  id: 'imprint',
+  name: 'Imprint',
+  description: 'Frameless EXIF text printed directly on the photo',
+  style: {
+    fontFamily: geistSans.style.fontFamily,
+    fontSize: 16,
+    textColor: '#ffffff',
+    backgroundColor: 'rgba(0, 0, 0, 0)',
+    opacity: 0,
+    padding: 12,
+    borderRadius: 0,
+  },
+  position: {
+    x: 0,
+    y: 0,
+    width: 720,
+    height: 120,
+    alignment: 'left',
+  },
+  fontRequirements: [
+    { family: geistSans.style.fontFamily },
+    { family: geistSans.style.fontFamily, weights: [600] },
+  ],
+  customDraw: 'imprint',
+  fields: createStandardFields(),
+};

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -3,6 +3,7 @@ import { filmTemplate } from './film';
 import { technicalTemplate } from './technical';
 import { compactTemplate } from './compact';
 import { captionTemplate } from './caption';
+import { imprintTemplate } from './imprint';
 
 // Only include available templates. Missing presets are treated as not available.
 export const templates: Partial<Record<TemplatePreset, Template>> = {
@@ -10,6 +11,13 @@ export const templates: Partial<Record<TemplatePreset, Template>> = {
   technical: technicalTemplate,
   compact: compactTemplate,
   caption: captionTemplate,
+  imprint: imprintTemplate,
 };
 
-export { filmTemplate, technicalTemplate, compactTemplate, captionTemplate };
+export {
+  filmTemplate,
+  technicalTemplate,
+  compactTemplate,
+  captionTemplate,
+  imprintTemplate,
+};

--- a/src/types/template.ts
+++ b/src/types/template.ts
@@ -41,7 +41,7 @@ export interface Template {
   positionOverride?: (isPortrait: boolean) => PositionPreset;
   textShadow?: boolean;
   rotateForPortrait?: boolean;
-  customDraw?: 'caption' | 'technical' | 'compact';
+  customDraw?: 'caption' | 'technical' | 'compact' | 'imprint';
 }
 
 export interface TemplateField {
@@ -51,4 +51,9 @@ export interface TemplateField {
   format?: (value: string | null) => string;
 }
 
-export type TemplatePreset = 'film' | 'technical' | 'compact' | 'caption';
+export type TemplatePreset =
+  | 'film'
+  | 'technical'
+  | 'compact'
+  | 'caption'
+  | 'imprint';


### PR DESCRIPTION
## Summary
- 写真にフレーム無しで EXIF テキストを直接焼き付ける新テンプレート **Imprint** を追加。文字色は白/黒を切替可能（既存の Caption/Compact/Glass/Film と差別化された最もミニマルな選択肢）
- レンズ情報があれば機種名の下に独立行で表示。ロケーション情報も最下行に optional 表示（どちらも EXIF/IPTC に値がない場合は行ごと自動省略）
- 文字色トグルは Caption の "Invert colors" スイッチと同じビジュアルに統一

## レンダリング仕様
- 配置: 4 隅から選択可。左コーナーは左寄せ、右コーナーは右寄せに自動切替
- 行構成（上から順、すべて optional 行は欠落時に自動省略）:
  1. `MAKE` (weight 600, letter-spacing 0.04em) + `Model` (weight 400) — 同じ headline 行
  2. レンズ名 (regular, headline と params の中間サイズ)
  3. 日付 · ƒ/値 · シャッター · ISO · 焦点距離
  4. ロケーション
- フォント: Geist Sans (Compact/Glass と同じ)
- 可読性: textColor の輝度から自動選択した contrasting drop shadow を適用

## Test plan
- [ ] テンプレート選択カードに **Imprint** が出る
- [ ] 選択時に "Invert text color" スイッチが表示され、Caption の "Invert colors" と同じ見た目
- [ ] スイッチ ON/OFF で写真上のテキストが黒/白に切り替わる
- [ ] EXIF にレンズ情報がある画像で機種名の下にレンズ行が出る／無い画像では出ない
- [ ] EXIF/IPTC にロケーション情報がある画像で最下行に出る／無ければ非表示
- [ ] 4 隅すべての配置 (top-left / top-right / bottom-left / bottom-right) で寄せ方が意図通り
- [ ] 黒文字／白文字どちらも写真上で読める (contrast shadow 確認)
- [ ] ページリロード後も色選択が永続化されている
- [ ] 既存テンプレート (Caption / Compact / Glass / Film) の表示に regression なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)