### PR TITLE
feat(templates): add Gallery Placard template

### DIFF
--- a/src/components/editor/TemplateSelector.tsx
+++ b/src/components/editor/TemplateSelector.tsx
@@ -13,6 +13,12 @@ export function TemplateSelector() {
   const selectTemplate = useTemplateStore((state) => state.selectTemplate);
   const captionInvert = useSettingsStore((state) => state.captionInvert);
   const setCaptionInvert = useSettingsStore((state) => state.setCaptionInvert);
+  const galleryPlacardInvert = useSettingsStore(
+    (state) => state.galleryPlacardInvert
+  );
+  const setGalleryPlacardInvert = useSettingsStore(
+    (state) => state.setGalleryPlacardInvert
+  );
   const imprintColor = useSettingsStore((state) => state.imprintColor);
   const setImprintColor = useSettingsStore((state) => state.setImprintColor);
 
@@ -25,6 +31,11 @@ export function TemplateSelector() {
     { key: 'compact', name: 'Compact', description: '2×2 frosted info card' },
     { key: 'technical', name: 'Glass', description: 'Frosted glass card' },
     { key: 'imprint', name: 'Imprint', description: 'Frameless text on photo' },
+    {
+      key: 'gallery-placard',
+      name: 'Gallery Placard',
+      description: 'Museum-style ivory placard below photo',
+    },
     { key: 'film', name: 'Film', description: 'Vintage style' },
   ];
 
@@ -182,6 +193,42 @@ export function TemplateSelector() {
                 className={clsx(
                   'inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform',
                   captionInvert ? 'translate-x-6' : 'translate-x-1'
+                )}
+              />
+            </button>
+          </label>
+        </div>
+      )}
+
+      {selectedTemplate?.customDraw === 'gallery-placard' && (
+        <div className="mt-4 p-3 bg-gray-50 dark:bg-gray-700 rounded-lg transition-colors">
+          <label className="flex items-center justify-between cursor-pointer">
+            <div className="space-y-0.5">
+              <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                Invert colors
+              </h4>
+              <p className="text-xs text-gray-500 dark:text-gray-400">
+                Dark placard with ivory text
+              </p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={galleryPlacardInvert}
+              onClick={() => setGalleryPlacardInvert(!galleryPlacardInvert)}
+              className={clsx(
+                'relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors',
+                'focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2',
+                'dark:focus:ring-offset-gray-700',
+                galleryPlacardInvert
+                  ? 'bg-blue-600 dark:bg-blue-500'
+                  : 'bg-gray-300 dark:bg-gray-600'
+              )}
+            >
+              <span
+                className={clsx(
+                  'inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform',
+                  galleryPlacardInvert ? 'translate-x-6' : 'translate-x-1'
                 )}
               />
             </button>

--- a/src/hooks/useEffectiveTemplate.ts
+++ b/src/hooks/useEffectiveTemplate.ts
@@ -6,6 +6,9 @@ import type { Template } from '@/types/template';
 export function useEffectiveTemplate(): Template | null {
   const selectedTemplate = useTemplateStore((state) => state.selectedTemplate);
   const captionInvert = useSettingsStore((state) => state.captionInvert);
+  const galleryPlacardInvert = useSettingsStore(
+    (state) => state.galleryPlacardInvert
+  );
   const imprintColor = useSettingsStore((state) => state.imprintColor);
 
   return useMemo(() => {
@@ -22,6 +25,20 @@ export function useEffectiveTemplate(): Template | null {
       };
     }
 
+    if (
+      selectedTemplate.customDraw === 'gallery-placard' &&
+      galleryPlacardInvert
+    ) {
+      return {
+        ...selectedTemplate,
+        style: {
+          ...selectedTemplate.style,
+          backgroundColor: selectedTemplate.style.textColor,
+          textColor: selectedTemplate.style.backgroundColor,
+        },
+      };
+    }
+
     if (selectedTemplate.customDraw === 'imprint') {
       return {
         ...selectedTemplate,
@@ -33,5 +50,5 @@ export function useEffectiveTemplate(): Template | null {
     }
 
     return selectedTemplate;
-  }, [selectedTemplate, captionInvert, imprintColor]);
+  }, [selectedTemplate, captionInvert, galleryPlacardInvert, imprintColor]);
 }

--- a/src/services/canvasRenderer.ts
+++ b/src/services/canvasRenderer.ts
@@ -210,6 +210,54 @@ let imprintLayoutCache: {
   layout: ImprintLayout;
 } | null = null;
 
+interface GalleryPlacardLayout {
+  height: number;
+  paddingX: number;
+  paddingY: number;
+  contentHeight: number;
+  stacked: boolean;
+  leftColumnWidth: number;
+  rightColumnWidth: number;
+  columnGap: number;
+  serifFamily: string;
+  sansFamily: string;
+  makeFontSize: number;
+  makeLetterSpacing: string;
+  modelFontSize: number;
+  modelLineHeight: number;
+  lensFontSize: number;
+  lensLineHeight: number;
+  lensLetterSpacing: string;
+  paramsFontSize: number;
+  paramsLineHeight: number;
+  metaFontSize: number;
+  metaLineHeight: number;
+  makeToModelGap: number;
+  modelToLensGap: number;
+  rightRowGap: number;
+  ruleGap: number;
+  ruleThickness: number;
+  ruleWidth: number;
+  dividerThickness: number;
+  makeText: string | null;
+  modelLines: string[];
+  lensLines: string[];
+  paramsLines: string[];
+  dateLines: string[];
+  locationLines: string[];
+  showRule: boolean;
+  leftHeight: number;
+  rightHeight: number;
+  interSectionGap: number;
+  secondaryAlpha: number;
+  dividerAlpha: number;
+}
+
+let galleryPlacardLayoutCache: {
+  key: string;
+  layout: GalleryPlacardLayout;
+} | null = null;
+
 export class CanvasRenderer {
   static async render(options: RenderOptions): Promise<string> {
     const { canvas, image, template, exifData, settings } = options;
@@ -530,6 +578,17 @@ export class CanvasRenderer {
 
     if (template.customDraw === 'imprint') {
       const layout = this.buildImprintLayout(template, exifData, scaleFactor);
+      return layout.height;
+    }
+
+    if (template.customDraw === 'gallery-placard') {
+      const layout = this.buildGalleryPlacardLayout(
+        template,
+        exifData,
+        scaleFactor,
+        availableWidth ?? template.position.width * scaleFactor,
+        tempCtx
+      );
       return layout.height;
     }
 
@@ -2367,6 +2426,447 @@ export class CanvasRenderer {
     ctx.restore();
   }
 
+  private static buildGalleryPlacardExposureLine(
+    exifData: NormalizedExifData
+  ): string | null {
+    const aperture = exifData.aperture
+      ? exifData.aperture.replace(/^f\//i, 'ƒ/')
+      : null;
+    const iso = exifData.iso
+      ? /^iso\b/i.test(exifData.iso)
+        ? exifData.iso
+        : `ISO ${exifData.iso}`
+      : null;
+    const parts = [
+      exifData.focalLength,
+      aperture,
+      exifData.shutterSpeed,
+      iso,
+    ].filter((value): value is string => !!value);
+    return parts.length > 0 ? parts.join(' · ') : null;
+  }
+
+  private static formatGalleryPlacardDate(value: string | null): string | null {
+    if (!value) return null;
+    const m = value.match(/(\d{4})[\/\-:.](\d{2})[\/\-:.](\d{2})/);
+    if (m) {
+      const [, yyyy, mm, dd] = m;
+      return `${yyyy}.${mm}.${dd}`;
+    }
+    return value;
+  }
+
+  private static buildGalleryPlacardLayout(
+    template: Template,
+    exifData: NormalizedExifData,
+    scaleFactor: number,
+    availableWidth: number,
+    ctx: CanvasRenderingContext2D
+  ): GalleryPlacardLayout {
+    const cacheKey = JSON.stringify([
+      'gallery-placard',
+      template.id,
+      scaleFactor,
+      availableWidth,
+      exifData,
+    ]);
+    if (galleryPlacardLayoutCache?.key === cacheKey) {
+      return galleryPlacardLayoutCache.layout;
+    }
+
+    const measureCtx = ctx;
+    const sansFamily = template.style.fontFamily;
+    // Pair the body sans with the first declared non-matching font as serif.
+    // Falls back to sans if no second family was provided.
+    const serifReq = template.fontRequirements?.find(
+      (req) => req.family !== sansFamily
+    );
+    const serifFamily = serifReq?.family ?? sansFamily;
+
+    const basePadding = template.style.padding * scaleFactor;
+    const baseFontSize = Math.max(12, template.style.fontSize * scaleFactor);
+
+    const stacked = availableWidth < 720;
+
+    // Trim horizontal padding for narrow placards so column widths stay legible
+    const paddingX = stacked ? Math.max(16, basePadding * 0.7) : basePadding;
+    const paddingY = stacked ? Math.max(20, basePadding * 0.75) : basePadding;
+
+    const textAreaWidth = Math.max(0, availableWidth - paddingX * 2);
+    const columnGap = stacked ? 0 : Math.max(24, baseFontSize * 1.6);
+    // Sample favours a smaller left column (camera info) and a wider right
+    // column for the exposure/date/location list.
+    const leftColumnWidth = stacked
+      ? textAreaWidth
+      : Math.max(0, Math.floor((textAreaWidth - columnGap) * 0.42));
+    const rightColumnWidth = stacked
+      ? textAreaWidth
+      : Math.max(0, textAreaWidth - leftColumnWidth - columnGap);
+
+    const makeFontSize = Math.max(18, baseFontSize * 1.7);
+    const modelFontSize = Math.max(18, baseFontSize * 1.7);
+    const lensFontSize = Math.max(11, baseFontSize * 0.85);
+    // Right column unifies params/date/location at the same size,
+    // matching the editorial balance in the reference.
+    const paramsFontSize = Math.max(12, baseFontSize * 1.0);
+    const metaFontSize = paramsFontSize;
+
+    const modelLineHeight = modelFontSize * 1.15;
+    const lensLineHeight = lensFontSize * 1.4;
+    const paramsLineHeight = paramsFontSize * 1.4;
+    const metaLineHeight = metaFontSize * 1.4;
+
+    const makeLetterSpacing = '0.04em';
+    const lensLetterSpacing = '0.04em';
+
+    const makeToModelGap = makeFontSize * 0.18;
+    const modelToLensGap = modelFontSize * 0.5;
+    const rightRowGap = paramsFontSize * 0.7;
+    const ruleGap = paramsFontSize * 0.7;
+    const ruleThickness = Math.max(1, scaleFactor);
+    const dividerThickness = Math.max(1, scaleFactor);
+
+    const { make, model } = this.getCaptionCameraParts(exifData);
+    const makeText = make ? make.toUpperCase() : null;
+
+    measureCtx.font = `${modelFontSize}px ${serifFamily}`;
+    const modelLines = model
+      ? this.wrapText(measureCtx, model, leftColumnWidth)
+      : [];
+
+    measureCtx.font = `${lensFontSize}px ${sansFamily}`;
+    const lensLines = exifData.lens
+      ? this.wrapText(measureCtx, exifData.lens, leftColumnWidth)
+      : [];
+
+    const paramsText = this.buildGalleryPlacardExposureLine(exifData);
+    measureCtx.font = `${paramsFontSize}px ${sansFamily}`;
+    const paramsLines = paramsText
+      ? this.wrapText(measureCtx, paramsText, rightColumnWidth)
+      : [];
+
+    const dateText = this.formatGalleryPlacardDate(exifData.dateTime);
+    measureCtx.font = `${metaFontSize}px ${sansFamily}`;
+    const dateLines = dateText
+      ? this.wrapText(measureCtx, dateText, rightColumnWidth)
+      : [];
+    const locationText = exifData.location ?? null;
+    const locationLines = locationText
+      ? this.wrapText(measureCtx, locationText, rightColumnWidth)
+      : [];
+
+    const ruleWidth =
+      rightColumnWidth > 0
+        ? Math.min(rightColumnWidth, Math.max(80, rightColumnWidth * 0.55))
+        : 0;
+    const showRule =
+      paramsLines.length > 0 &&
+      (dateLines.length > 0 || locationLines.length > 0);
+
+    // Left column height
+    let leftHeight = 0;
+    if (makeText) {
+      leftHeight += makeFontSize;
+      if (modelLines.length > 0 || lensLines.length > 0) {
+        leftHeight += makeToModelGap;
+      }
+    }
+    if (modelLines.length > 0) {
+      leftHeight += modelFontSize + (modelLines.length - 1) * modelLineHeight;
+      if (lensLines.length > 0) {
+        leftHeight += modelToLensGap;
+      }
+    }
+    if (lensLines.length > 0) {
+      leftHeight += lensFontSize + (lensLines.length - 1) * lensLineHeight;
+    }
+
+    // Right column height (matches drawing logic exactly)
+    let rightHeight = 0;
+    if (paramsLines.length > 0) {
+      rightHeight +=
+        paramsFontSize + (paramsLines.length - 1) * paramsLineHeight;
+      if (showRule) {
+        rightHeight += ruleGap + ruleThickness;
+        if (dateLines.length > 0 || locationLines.length > 0) {
+          rightHeight += ruleGap;
+        }
+      } else if (dateLines.length > 0 || locationLines.length > 0) {
+        rightHeight += rightRowGap;
+      }
+    }
+    if (dateLines.length > 0) {
+      rightHeight += metaFontSize + (dateLines.length - 1) * metaLineHeight;
+      if (locationLines.length > 0) rightHeight += rightRowGap;
+    }
+    if (locationLines.length > 0) {
+      rightHeight += metaFontSize + (locationLines.length - 1) * metaLineHeight;
+    }
+
+    const interSectionGap =
+      stacked && leftHeight > 0 && rightHeight > 0 ? rightRowGap * 1.4 : 0;
+    const contentHeight = stacked
+      ? leftHeight + interSectionGap + rightHeight
+      : Math.max(leftHeight, rightHeight);
+
+    const layout: GalleryPlacardLayout = {
+      height: paddingY + contentHeight + paddingY,
+      paddingX,
+      paddingY,
+      contentHeight,
+      stacked,
+      leftColumnWidth,
+      rightColumnWidth,
+      columnGap,
+      serifFamily,
+      sansFamily,
+      makeFontSize,
+      makeLetterSpacing,
+      modelFontSize,
+      modelLineHeight,
+      lensFontSize,
+      lensLineHeight,
+      lensLetterSpacing,
+      paramsFontSize,
+      paramsLineHeight,
+      metaFontSize,
+      metaLineHeight,
+      makeToModelGap,
+      modelToLensGap,
+      rightRowGap,
+      ruleGap,
+      ruleThickness,
+      ruleWidth,
+      dividerThickness,
+      makeText,
+      modelLines,
+      lensLines,
+      paramsLines,
+      dateLines,
+      locationLines,
+      showRule,
+      leftHeight,
+      rightHeight,
+      interSectionGap,
+      secondaryAlpha: 0.92,
+      dividerAlpha: 0.28,
+    };
+    galleryPlacardLayoutCache = { key: cacheKey, layout };
+    return layout;
+  }
+
+  private static drawGalleryPlacardLeftColumn(
+    ctx: CanvasRenderingContext2D,
+    layout: GalleryPlacardLayout,
+    x: number,
+    topY: number
+  ): void {
+    let cursorY = topY;
+    ctx.save();
+    ctx.textAlign = 'left';
+
+    if (layout.makeText) {
+      ctx.save();
+      ctx.font = `600 ${layout.makeFontSize}px ${layout.serifFamily}`;
+      (
+        ctx as CanvasRenderingContext2D & { letterSpacing?: string }
+      ).letterSpacing = layout.makeLetterSpacing;
+      ctx.fillText(layout.makeText, x, cursorY + layout.makeFontSize);
+      ctx.restore();
+      cursorY += layout.makeFontSize;
+      if (layout.modelLines.length > 0 || layout.lensLines.length > 0) {
+        cursorY += layout.makeToModelGap;
+      }
+    }
+
+    if (layout.modelLines.length > 0) {
+      ctx.save();
+      ctx.font = `${layout.modelFontSize}px ${layout.serifFamily}`;
+      let y = cursorY + layout.modelFontSize;
+      for (const line of layout.modelLines) {
+        ctx.fillText(line, x, y);
+        y += layout.modelLineHeight;
+      }
+      ctx.restore();
+      cursorY +=
+        layout.modelFontSize +
+        (layout.modelLines.length - 1) * layout.modelLineHeight;
+      if (layout.lensLines.length > 0) cursorY += layout.modelToLensGap;
+    }
+
+    if (layout.lensLines.length > 0) {
+      ctx.save();
+      ctx.globalAlpha = layout.secondaryAlpha;
+      ctx.font = `${layout.lensFontSize}px ${layout.sansFamily}`;
+      (
+        ctx as CanvasRenderingContext2D & { letterSpacing?: string }
+      ).letterSpacing = layout.lensLetterSpacing;
+      let y = cursorY + layout.lensFontSize;
+      for (const line of layout.lensLines) {
+        ctx.fillText(line, x, y);
+        y += layout.lensLineHeight;
+      }
+      ctx.restore();
+    }
+
+    ctx.restore();
+  }
+
+  private static drawGalleryPlacardRightColumn(
+    ctx: CanvasRenderingContext2D,
+    layout: GalleryPlacardLayout,
+    x: number,
+    topY: number
+  ): void {
+    let cursorY = topY;
+    ctx.save();
+    ctx.textAlign = 'left';
+
+    if (layout.paramsLines.length > 0) {
+      ctx.save();
+      ctx.font = `${layout.paramsFontSize}px ${layout.sansFamily}`;
+      let y = cursorY + layout.paramsFontSize;
+      for (const line of layout.paramsLines) {
+        ctx.fillText(line, x, y);
+        y += layout.paramsLineHeight;
+      }
+      ctx.restore();
+      cursorY +=
+        layout.paramsFontSize +
+        (layout.paramsLines.length - 1) * layout.paramsLineHeight;
+
+      if (layout.showRule) {
+        cursorY += layout.ruleGap;
+        ctx.save();
+        ctx.globalAlpha = layout.dividerAlpha;
+        ctx.fillRect(
+          x,
+          Math.round(cursorY),
+          layout.ruleWidth,
+          layout.ruleThickness
+        );
+        ctx.restore();
+        cursorY += layout.ruleThickness;
+        if (layout.dateLines.length > 0 || layout.locationLines.length > 0) {
+          cursorY += layout.ruleGap;
+        }
+      } else if (
+        layout.dateLines.length > 0 ||
+        layout.locationLines.length > 0
+      ) {
+        cursorY += layout.rightRowGap;
+      }
+    }
+
+    if (layout.dateLines.length > 0) {
+      ctx.save();
+      ctx.globalAlpha = layout.secondaryAlpha;
+      ctx.font = `${layout.metaFontSize}px ${layout.sansFamily}`;
+      let y = cursorY + layout.metaFontSize;
+      for (const line of layout.dateLines) {
+        ctx.fillText(line, x, y);
+        y += layout.metaLineHeight;
+      }
+      ctx.restore();
+      cursorY +=
+        layout.metaFontSize +
+        (layout.dateLines.length - 1) * layout.metaLineHeight;
+      if (layout.locationLines.length > 0) cursorY += layout.rightRowGap;
+    }
+
+    if (layout.locationLines.length > 0) {
+      ctx.save();
+      ctx.globalAlpha = layout.secondaryAlpha;
+      ctx.font = `${layout.metaFontSize}px ${layout.sansFamily}`;
+      let y = cursorY + layout.metaFontSize;
+      for (const line of layout.locationLines) {
+        ctx.fillText(line, x, y);
+        y += layout.metaLineHeight;
+      }
+      ctx.restore();
+    }
+
+    ctx.restore();
+  }
+
+  private static drawGalleryPlacardTemplate(
+    ctx: CanvasRenderingContext2D,
+    template: Template,
+    exifData: NormalizedExifData,
+    scaleFactor: number
+  ): void {
+    const { style, position } = template;
+    const scaledX = position.x;
+    const scaledY = position.y;
+    const scaledWidth = position.width * scaleFactor;
+
+    const layout = this.buildGalleryPlacardLayout(
+      template,
+      exifData,
+      scaleFactor,
+      scaledWidth,
+      ctx
+    );
+
+    // Background — flat warm ivory rectangle, no rounded corners
+    ctx.save();
+    ctx.globalAlpha = style.opacity;
+    ctx.fillStyle = style.backgroundColor;
+    ctx.fillRect(scaledX, scaledY, scaledWidth, layout.height);
+    ctx.restore();
+
+    ctx.save();
+    ctx.fillStyle = style.textColor;
+    ctx.textBaseline = 'alphabetic';
+    ctx.shadowColor = 'transparent';
+    ctx.shadowBlur = 0;
+    ctx.shadowOffsetX = 0;
+    ctx.shadowOffsetY = 0;
+
+    const contentTop = scaledY + (layout.height - layout.contentHeight) / 2;
+    const leftX = scaledX + layout.paddingX;
+
+    if (layout.stacked) {
+      let cursorY = contentTop;
+      this.drawGalleryPlacardLeftColumn(ctx, layout, leftX, cursorY);
+      cursorY += layout.leftHeight;
+      if (layout.leftHeight > 0 && layout.rightHeight > 0) {
+        cursorY += layout.interSectionGap;
+      }
+      this.drawGalleryPlacardRightColumn(ctx, layout, leftX, cursorY);
+    } else {
+      // Vertical hairline divider between columns
+      if (layout.contentHeight > 0 && layout.rightColumnWidth > 0) {
+        const dividerX =
+          scaledX +
+          layout.paddingX +
+          layout.leftColumnWidth +
+          layout.columnGap / 2;
+        ctx.save();
+        ctx.globalAlpha = layout.dividerAlpha;
+        ctx.fillRect(
+          Math.round(dividerX - layout.dividerThickness / 2),
+          contentTop,
+          layout.dividerThickness,
+          layout.contentHeight
+        );
+        ctx.restore();
+      }
+
+      const leftTop =
+        contentTop + (layout.contentHeight - layout.leftHeight) / 2;
+      this.drawGalleryPlacardLeftColumn(ctx, layout, leftX, leftTop);
+
+      const rightX =
+        scaledX + layout.paddingX + layout.leftColumnWidth + layout.columnGap;
+      const rightTop =
+        contentTop + (layout.contentHeight - layout.rightHeight) / 2;
+      this.drawGalleryPlacardRightColumn(ctx, layout, rightX, rightTop);
+    }
+
+    ctx.restore();
+  }
+
   // Heuristic: treat #fff/white as "light", everything else as dark.
   // Used to pick a contrasting drop shadow for the imprint text.
   private static isLightTextColor(color: string): boolean {
@@ -2430,6 +2930,11 @@ export class CanvasRenderer {
         scaleFactor,
         options?.overlayPosition
       );
+      return;
+    }
+
+    if (template.customDraw === 'gallery-placard') {
+      this.drawGalleryPlacardTemplate(ctx, template, exifData, scaleFactor);
       return;
     }
 

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -7,9 +7,11 @@ export type ImprintColor = 'white' | 'black';
 interface SettingsState {
   canvasSettings: CanvasSettings;
   captionInvert: boolean;
+  galleryPlacardInvert: boolean;
   imprintColor: ImprintColor;
   updateCanvasSettings: (settings: Partial<CanvasSettings>) => void;
   setCaptionInvert: (value: boolean) => void;
+  setGalleryPlacardInvert: (value: boolean) => void;
   setImprintColor: (value: ImprintColor) => void;
   resetToDefaults: () => void;
 }
@@ -28,6 +30,7 @@ export const useSettingsStore = create<SettingsState>()(
     (set) => ({
       canvasSettings: defaultCanvasSettings,
       captionInvert: false,
+      galleryPlacardInvert: false,
       imprintColor: 'white',
 
       updateCanvasSettings: (settingsUpdate) =>
@@ -37,12 +40,15 @@ export const useSettingsStore = create<SettingsState>()(
 
       setCaptionInvert: (value) => set({ captionInvert: value }),
 
+      setGalleryPlacardInvert: (value) => set({ galleryPlacardInvert: value }),
+
       setImprintColor: (value) => set({ imprintColor: value }),
 
       resetToDefaults: () =>
         set({
           canvasSettings: defaultCanvasSettings,
           captionInvert: false,
+          galleryPlacardInvert: false,
           imprintColor: 'white',
         }),
     }),
@@ -51,6 +57,7 @@ export const useSettingsStore = create<SettingsState>()(
       partialize: (state) => ({
         canvasSettings: state.canvasSettings,
         captionInvert: state.captionInvert,
+        galleryPlacardInvert: state.galleryPlacardInvert,
         imprintColor: state.imprintColor,
       }),
     }

--- a/src/templates/__tests__/galleryPlacard.test.ts
+++ b/src/templates/__tests__/galleryPlacard.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// next/font/google and next/font/local are next.js build-time loaders that
+// throw outside the next runtime. Stub them so importing the template
+// registry (which transitively pulls in fonts.ts) works under vitest.
+vi.mock('next/font/google', () => {
+  const stub = () => ({ style: { fontFamily: 'stub' } });
+  return { Geist: stub, Geist_Mono: stub, Besley: stub };
+});
+vi.mock('next/font/local', () => ({
+  default: () => ({ style: { fontFamily: 'stub-local' } }),
+}));
+
+import { templates, galleryPlacardTemplate } from '@/templates';
+import { CanvasRenderer } from '@/services/canvasRenderer';
+import type { NormalizedExifData } from '@/types/exif';
+
+const fullExif: NormalizedExifData = {
+  camera: 'Sony α1 II',
+  cameraMake: 'Sony',
+  cameraModel: 'α1 II',
+  lens: 'FE 35mm F1.4 GM',
+  focalLength: '35mm',
+  iso: 'ISO 200',
+  aperture: 'f/1.4',
+  shutterSpeed: '1/500s',
+  dateTime: '2026/05/04 14:30:00',
+  location: 'Lisbon, Portugal',
+};
+
+const emptyExif: NormalizedExifData = {
+  camera: null,
+  cameraMake: null,
+  cameraModel: null,
+  lens: null,
+  focalLength: null,
+  iso: null,
+  aperture: null,
+  shutterSpeed: null,
+  dateTime: null,
+  location: null,
+};
+
+describe('galleryPlacardTemplate', () => {
+  it('is registered under the gallery-placard preset', () => {
+    expect(templates['gallery-placard']).toBe(galleryPlacardTemplate);
+    expect(galleryPlacardTemplate.id).toBe('gallery-placard');
+    expect(galleryPlacardTemplate.name).toBe('Gallery Placard');
+  });
+
+  it('uses bottom-padding layout and opts into custom drawing', () => {
+    expect(galleryPlacardTemplate.layout).toBe('bottom-padding');
+    expect(galleryPlacardTemplate.customDraw).toBe('gallery-placard');
+  });
+
+  it('paints a warm ivory background', () => {
+    expect(galleryPlacardTemplate.style.backgroundColor.toLowerCase()).toMatch(
+      /^#f[46]/
+    );
+  });
+
+  it('estimates a positive bottom-padding height with full EXIF', () => {
+    const h = CanvasRenderer.estimateBottomPaddingHeight(
+      galleryPlacardTemplate,
+      fullExif,
+      1000,
+      1000
+    );
+    expect(h).toBeGreaterThan(0);
+  });
+
+  it('estimates a positive bottom-padding height with empty EXIF', () => {
+    const h = CanvasRenderer.estimateBottomPaddingHeight(
+      galleryPlacardTemplate,
+      emptyExif,
+      1000,
+      1000
+    );
+    expect(h).toBeGreaterThan(0);
+  });
+
+  it('handles narrow portrait canvases without throwing', () => {
+    expect(() =>
+      CanvasRenderer.estimateBottomPaddingHeight(
+        galleryPlacardTemplate,
+        fullExif,
+        600,
+        900
+      )
+    ).not.toThrow();
+  });
+});

--- a/src/templates/galleryPlacard.ts
+++ b/src/templates/galleryPlacard.ts
@@ -1,0 +1,34 @@
+import type { Template } from '@/types/template';
+import { createStandardFields } from './shared/baseFields';
+import { geistSans, besley } from '@/styles/fonts';
+
+export const galleryPlacardTemplate: Template = {
+  id: 'gallery-placard',
+  name: 'Gallery Placard',
+  description: 'Museum-style bottom placard with refined camera metadata',
+  layout: 'bottom-padding',
+  style: {
+    fontFamily: geistSans.style.fontFamily,
+    fontSize: 16,
+    textColor: '#2a2621',
+    backgroundColor: '#f4efe6',
+    opacity: 1,
+    padding: 44,
+    borderRadius: 0,
+  },
+  position: {
+    x: 0,
+    y: 0,
+    width: 1000,
+    height: 240,
+    alignment: 'left',
+  },
+  fontRequirements: [
+    { family: geistSans.style.fontFamily },
+    { family: geistSans.style.fontFamily, weights: [600] },
+    { family: besley.style.fontFamily },
+    { family: besley.style.fontFamily, weights: [600] },
+  ],
+  customDraw: 'gallery-placard',
+  fields: createStandardFields(),
+};

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -4,6 +4,7 @@ import { technicalTemplate } from './technical';
 import { compactTemplate } from './compact';
 import { captionTemplate } from './caption';
 import { imprintTemplate } from './imprint';
+import { galleryPlacardTemplate } from './galleryPlacard';
 
 // Only include available templates. Missing presets are treated as not available.
 export const templates: Partial<Record<TemplatePreset, Template>> = {
@@ -12,6 +13,7 @@ export const templates: Partial<Record<TemplatePreset, Template>> = {
   compact: compactTemplate,
   caption: captionTemplate,
   imprint: imprintTemplate,
+  'gallery-placard': galleryPlacardTemplate,
 };
 
 export {
@@ -20,4 +22,5 @@ export {
   compactTemplate,
   captionTemplate,
   imprintTemplate,
+  galleryPlacardTemplate,
 };

--- a/src/types/template.ts
+++ b/src/types/template.ts
@@ -41,7 +41,12 @@ export interface Template {
   positionOverride?: (isPortrait: boolean) => PositionPreset;
   textShadow?: boolean;
   rotateForPortrait?: boolean;
-  customDraw?: 'caption' | 'technical' | 'compact' | 'imprint';
+  customDraw?:
+    | 'caption'
+    | 'technical'
+    | 'compact'
+    | 'imprint'
+    | 'gallery-placard';
 }
 
 export interface TemplateField {
@@ -56,4 +61,5 @@ export type TemplatePreset =
   | 'technical'
   | 'compact'
   | 'caption'
-  | 'imprint';
+  | 'imprint'
+  | 'gallery-placard';


### PR DESCRIPTION
## Summary

Adds a new museum/gallery-style EXIF overlay template called **Gallery Placard**. The placard sits below the photo (using the existing `bottom-padding` layout) on a warm ivory background, with camera info on the left and exposure/date/location on the right, separated by a hairline divider.

- New template registered as `gallery-placard` and exposed in the template picker
- Custom canvas drawer (`buildGalleryPlacardLayout` / `drawGalleryPlacardTemplate`) with dynamic height, two-column editorial layout, and a stacked single-column variant for narrow widths (`< 720` scaled px)
- Reuses the caption camera-parts splitter so e.g. `SONY ILCE-1M2` does not render `SONY SONY ILCE-1M2`; missing fields are dropped silently rather than rendering `N/A`
- Aperture is normalized to `ƒ/`, ISO is prefixed when missing, dates are reformatted to `YYYY.MM.DD`
- Invert toggle (Caption-style switch) swaps background/text for a dark variant; persisted via the existing settings store

## Visual layout

```
┌──────────────────────────────────────────────┐
│                  photo                       │
└──────────────────────────────────────────────┘
┌──────────────────────────────────────────────┐
│  SONY              │  35mm · ƒ/1.4 · 1/500s  │
│  α1 II             │  ─────────────────────  │
│  FE 35mm F1.4 GM   │  2026.05.04             │
│                    │  Lisbon, Portugal       │
└──────────────────────────────────────────────┘
```

Stacked layout (narrow widths) places the right column below the left, with the horizontal rule acting as the divider.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npx tsc --noEmit`
- [x] `npm test` (82 passed, includes new `galleryPlacard.test.ts`)
- [x] `npm run build`
- [x] Manual visual review against the gallery-placard reference comp
- [ ] Spot-check landscape, portrait, and small-preview canvases in the dev server
- [ ] Confirm the invert toggle persists across reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)