### PR TITLE
tweak(templates): darken Gallery Placard invert background

### DIFF
--- a/src/hooks/useEffectiveTemplate.ts
+++ b/src/hooks/useEffectiveTemplate.ts
@@ -33,7 +33,7 @@ export function useEffectiveTemplate(): Template | null {
         ...selectedTemplate,
         style: {
           ...selectedTemplate.style,
-          backgroundColor: selectedTemplate.style.textColor,
+          backgroundColor: '#0d0b08',
           textColor: selectedTemplate.style.backgroundColor,
         },
       };


### PR DESCRIPTION
## Summary
- Gallery Placard の Invert colors 切替時、背景色を元の `textColor` (#2a2621, ウォームグレー) ではなく明示的な `#0d0b08` (ほぼ黒・微かに暖色) に変更
- ユーザーの希望「invert 時の黒背景をもっと黒に近づけたい」への対応
- 文字色は引き続きテンプレート本来の背景色 (#f4efe6 アイボリー) を流用しコントラストを維持

## Test plan
- [ ] ローカルで Gallery Placard を選択し Invert colors をトグルして背景がほぼ黒になることを確認
- [ ] 通常モード（非 invert）の見た目に変化がないことを確認
- [ ] アイボリー文字がガビらず読めることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)