### PR TITLE
feat(templates): add side and split layouts to Gallery Placard

### DIFF
--- a/src/hooks/useCanvasRenderer.ts
+++ b/src/hooks/useCanvasRenderer.ts
@@ -4,7 +4,7 @@ import { ImageProcessor } from '@/services/imageProcessor';
 import { CanvasRenderer } from '@/services/canvasRenderer';
 import type { NormalizedExifData } from '@/types/exif';
 import type { ProcessedImage } from '@/types/image';
-import type { Template } from '@/types/template';
+import type { PositionPreset, Template } from '@/types/template';
 import { getDisplayBounds, useResponsiveCanvas } from './useResponsiveCanvas';
 import { useEffectiveExifData } from './useEffectiveExifData';
 import { useEffectiveTemplate } from './useEffectiveTemplate';
@@ -24,7 +24,8 @@ function computePreviewRenderSize(
   imageWidth: number,
   imageHeight: number,
   template: Template,
-  exifData: NormalizedExifData
+  exifData: NormalizedExifData,
+  overlayPosition: PositionPreset
 ): { width: number; height: number } {
   const { width: fullW, height: fullH } = CanvasRenderer.calculateOptimalSize(
     imageWidth,
@@ -34,10 +35,17 @@ function computePreviewRenderSize(
     template,
     exifData,
     fullW,
-    fullH
+    fullH,
+    overlayPosition
   );
+  const sidePad = CanvasRenderer.estimateGalleryPlacardSidePadding(
+    template,
+    fullW,
+    overlayPosition
+  );
+  const totalFullW = fullW + sidePad.leftPad + sidePad.rightPad;
   const totalFullH = fullH + bpFull;
-  const fullAspect = fullW / totalFullH;
+  const fullAspect = totalFullW / totalFullH;
 
   const { maxDisplayWidth, maxDisplayHeight } = getDisplayBounds();
   let displayCanvasW: number;
@@ -50,12 +58,13 @@ function computePreviewRenderSize(
     displayCanvasW = displayCanvasH * fullAspect;
   }
 
-  // settings.width/height represent the image area (without bottom padding);
-  // render() re-adds the padding internally. Convert from full-canvas display
-  // size back to image-area display size.
-  const imageAreaRatio = totalFullH > 0 ? fullH / totalFullH : 1;
-  const displayBaseW = displayCanvasW;
-  const displayBaseH = displayCanvasH * imageAreaRatio;
+  // settings.width/height represent the image area (without bottom/side
+  // padding); render() re-adds the padding internally. Convert from full-canvas
+  // display size back to image-area display size.
+  const widthRatio = totalFullW > 0 ? fullW / totalFullW : 1;
+  const heightRatio = totalFullH > 0 ? fullH / totalFullH : 1;
+  const displayBaseW = displayCanvasW * widthRatio;
+  const displayBaseH = displayCanvasH * heightRatio;
 
   return {
     width: Math.max(1, Math.round(displayBaseW * PREVIEW_OVERSAMPLE)),
@@ -104,7 +113,8 @@ export function useCanvasRenderer(currentImage: ProcessedImage | null) {
             currentImage.width,
             currentImage.height,
             selectedTemplate,
-            exifData
+            exifData,
+            canvasSettings.overlayPosition
           );
 
         await CanvasRenderer.render({

--- a/src/services/canvasRenderer.ts
+++ b/src/services/canvasRenderer.ts
@@ -210,6 +210,9 @@ let imprintLayoutCache: {
   layout: ImprintLayout;
 } | null = null;
 
+type GalleryPlacardMode = 'bottom' | 'left' | 'right' | 'split';
+type GalleryPlacardSection = 'all' | 'left-only' | 'right-only';
+
 interface GalleryPlacardLayout {
   height: number;
   paddingX: number;
@@ -275,7 +278,32 @@ export class CanvasRenderer {
     const baseHeight = settings.height;
     const scaleFactor = Math.min(baseWidth, baseHeight) / 1000; // Base scale for 1000px
     const isBottomPadding = template.layout === 'bottom-padding';
-    const bottomPaddingHeight = isBottomPadding
+    const galleryPlacardMode = this.resolveGalleryPlacardMode(
+      template,
+      settings.overlayPosition
+    );
+    const isGalleryPlacardSide =
+      galleryPlacardMode === 'left' ||
+      galleryPlacardMode === 'right' ||
+      galleryPlacardMode === 'split';
+    const galleryLeftPad = isGalleryPlacardSide
+      ? galleryPlacardMode === 'left' || galleryPlacardMode === 'split'
+        ? this.getGalleryPlacardSidePanelWidth(
+            baseWidth,
+            galleryPlacardMode === 'split'
+          )
+        : 0
+      : 0;
+    const galleryRightPad = isGalleryPlacardSide
+      ? galleryPlacardMode === 'right' || galleryPlacardMode === 'split'
+        ? this.getGalleryPlacardSidePanelWidth(
+            baseWidth,
+            galleryPlacardMode === 'split'
+          )
+        : 0
+      : 0;
+    const useStandardBottomPadding = isBottomPadding && !isGalleryPlacardSide;
+    const bottomPaddingHeight = useStandardBottomPadding
       ? this.calculateDynamicTemplateHeight(
           template,
           exifData,
@@ -283,7 +311,7 @@ export class CanvasRenderer {
           baseWidth
         )
       : 0;
-    const canvasWidth = baseWidth;
+    const canvasWidth = baseWidth + galleryLeftPad + galleryRightPad;
     const canvasHeight = baseHeight + bottomPaddingHeight;
 
     // Set actual size in memory (scaled for device pixel ratio)
@@ -302,7 +330,12 @@ export class CanvasRenderer {
 
     let drawWidth, drawHeight, drawX, drawY;
 
-    if (isBottomPadding) {
+    if (isGalleryPlacardSide) {
+      drawWidth = baseWidth;
+      drawHeight = baseHeight;
+      drawX = galleryLeftPad;
+      drawY = 0;
+    } else if (isBottomPadding) {
       drawWidth = baseWidth;
       drawHeight = baseHeight;
       drawX = 0;
@@ -380,25 +413,58 @@ export class CanvasRenderer {
         ...settings,
         overlayPosition: template.positionOverride(isPortraitImage),
       };
-    } else if (isBottomPadding) {
+    } else if (useStandardBottomPadding) {
       effectiveSettings = { ...settings, overlayPosition: 'bottom-left' };
     }
 
-    const dynamicTemplate = this.calculateDynamicPosition(
-      template,
-      effectiveSettings,
-      canvasWidth,
-      canvasHeight,
-      exifData,
-      { drawX, drawY, drawWidth, drawHeight },
-      scaleFactor
-    );
+    if (isGalleryPlacardSide) {
+      if (galleryLeftPad > 0) {
+        const leftSections: GalleryPlacardSection =
+          galleryPlacardMode === 'split' ? 'left-only' : 'all';
+        this.drawGalleryPlacardPanel(
+          ctx,
+          template,
+          exifData,
+          scaleFactor,
+          0,
+          0,
+          galleryLeftPad,
+          baseHeight,
+          leftSections
+        );
+      }
+      if (galleryRightPad > 0) {
+        const rightSections: GalleryPlacardSection =
+          galleryPlacardMode === 'split' ? 'right-only' : 'all';
+        this.drawGalleryPlacardPanel(
+          ctx,
+          template,
+          exifData,
+          scaleFactor,
+          galleryLeftPad + baseWidth,
+          0,
+          galleryRightPad,
+          baseHeight,
+          rightSections
+        );
+      }
+    } else {
+      const dynamicTemplate = this.calculateDynamicPosition(
+        template,
+        effectiveSettings,
+        canvasWidth,
+        canvasHeight,
+        exifData,
+        { drawX, drawY, drawWidth, drawHeight },
+        scaleFactor
+      );
 
-    // Draw template overlay with scaling
-    this.drawTemplate(ctx, dynamicTemplate, exifData, scaleFactor, {
-      imageIsPortrait: isPortraitImage,
-      overlayPosition: effectiveSettings.overlayPosition,
-    });
+      // Draw template overlay with scaling
+      this.drawTemplate(ctx, dynamicTemplate, exifData, scaleFactor, {
+        imageIsPortrait: isPortraitImage,
+        overlayPosition: effectiveSettings.overlayPosition,
+      });
+    }
 
     // Return as data URL
     return canvas.toDataURL(
@@ -2426,6 +2492,36 @@ export class CanvasRenderer {
     ctx.restore();
   }
 
+  private static resolveGalleryPlacardMode(
+    template: Template,
+    overlayPosition: PositionPreset
+  ): GalleryPlacardMode | null {
+    if (template.customDraw !== 'gallery-placard') return null;
+    switch (overlayPosition) {
+      case 'top-left':
+        return 'left';
+      case 'top-right':
+        return 'right';
+      case 'bottom-right':
+        return 'split';
+      case 'bottom-left':
+      default:
+        return 'bottom';
+    }
+  }
+
+  private static getGalleryPlacardSidePanelWidth(
+    baseWidth: number,
+    isSplit: boolean
+  ): number {
+    const factor = isSplit ? 0.22 : 0.3;
+    const minWidth = isSplit ? 200 : 240;
+    const maxWidth = baseWidth * (isSplit ? 0.32 : 0.45);
+    return Math.round(
+      Math.max(minWidth, Math.min(maxWidth, baseWidth * factor))
+    );
+  }
+
   private static buildGalleryPlacardExposureLine(
     exifData: NormalizedExifData
   ): string | null {
@@ -2461,14 +2557,22 @@ export class CanvasRenderer {
     exifData: NormalizedExifData,
     scaleFactor: number,
     availableWidth: number,
-    ctx: CanvasRenderingContext2D
+    ctx: CanvasRenderingContext2D,
+    options?: { forceStacked?: boolean; sections?: GalleryPlacardSection }
   ): GalleryPlacardLayout {
+    const sections: GalleryPlacardSection = options?.sections ?? 'all';
+    const includeLeft = sections === 'all' || sections === 'left-only';
+    const includeRight = sections === 'all' || sections === 'right-only';
+    const forceStacked = options?.forceStacked ?? false;
+
     const cacheKey = JSON.stringify([
       'gallery-placard',
       template.id,
       scaleFactor,
       availableWidth,
       exifData,
+      sections,
+      forceStacked,
     ]);
     if (galleryPlacardLayoutCache?.key === cacheKey) {
       return galleryPlacardLayoutCache.layout;
@@ -2486,22 +2590,40 @@ export class CanvasRenderer {
     const basePadding = template.style.padding * scaleFactor;
     const baseFontSize = Math.max(12, template.style.fontSize * scaleFactor);
 
-    const stacked = availableWidth < 720;
+    const stacked = forceStacked || availableWidth < 720;
 
     // Trim horizontal padding for narrow placards so column widths stay legible
     const paddingX = stacked ? Math.max(16, basePadding * 0.7) : basePadding;
     const paddingY = stacked ? Math.max(20, basePadding * 0.75) : basePadding;
 
     const textAreaWidth = Math.max(0, availableWidth - paddingX * 2);
-    const columnGap = stacked ? 0 : Math.max(24, baseFontSize * 1.6);
+    const singleSection = sections !== 'all';
+    const columnGap =
+      stacked || singleSection ? 0 : Math.max(24, baseFontSize * 1.6);
     // Sample favours a smaller left column (camera info) and a wider right
-    // column for the exposure/date/location list.
-    const leftColumnWidth = stacked
-      ? textAreaWidth
-      : Math.max(0, Math.floor((textAreaWidth - columnGap) * 0.42));
-    const rightColumnWidth = stacked
-      ? textAreaWidth
-      : Math.max(0, textAreaWidth - leftColumnWidth - columnGap);
+    // column for the exposure/date/location list. When only one section is
+    // rendered, that section claims the full text area.
+    let leftColumnWidth: number;
+    let rightColumnWidth: number;
+    if (sections === 'left-only') {
+      leftColumnWidth = textAreaWidth;
+      rightColumnWidth = 0;
+    } else if (sections === 'right-only') {
+      leftColumnWidth = 0;
+      rightColumnWidth = textAreaWidth;
+    } else if (stacked) {
+      leftColumnWidth = textAreaWidth;
+      rightColumnWidth = textAreaWidth;
+    } else {
+      leftColumnWidth = Math.max(
+        0,
+        Math.floor((textAreaWidth - columnGap) * 0.42)
+      );
+      rightColumnWidth = Math.max(
+        0,
+        textAreaWidth - leftColumnWidth - columnGap
+      );
+    }
 
     const makeFontSize = Math.max(18, baseFontSize * 1.7);
     const modelFontSize = Math.max(18, baseFontSize * 1.7);
@@ -2527,30 +2649,36 @@ export class CanvasRenderer {
     const dividerThickness = Math.max(1, scaleFactor);
 
     const { make, model } = this.getCaptionCameraParts(exifData);
-    const makeText = make ? make.toUpperCase() : null;
+    const makeText = includeLeft && make ? make.toUpperCase() : null;
 
     measureCtx.font = `${modelFontSize}px ${serifFamily}`;
-    const modelLines = model
-      ? this.wrapText(measureCtx, model, leftColumnWidth)
-      : [];
+    const modelLines =
+      includeLeft && model
+        ? this.wrapText(measureCtx, model, leftColumnWidth)
+        : [];
 
     measureCtx.font = `${lensFontSize}px ${sansFamily}`;
-    const lensLines = exifData.lens
-      ? this.wrapText(measureCtx, exifData.lens, leftColumnWidth)
-      : [];
+    const lensLines =
+      includeLeft && exifData.lens
+        ? this.wrapText(measureCtx, exifData.lens, leftColumnWidth)
+        : [];
 
-    const paramsText = this.buildGalleryPlacardExposureLine(exifData);
+    const paramsText = includeRight
+      ? this.buildGalleryPlacardExposureLine(exifData)
+      : null;
     measureCtx.font = `${paramsFontSize}px ${sansFamily}`;
     const paramsLines = paramsText
       ? this.wrapText(measureCtx, paramsText, rightColumnWidth)
       : [];
 
-    const dateText = this.formatGalleryPlacardDate(exifData.dateTime);
+    const dateText = includeRight
+      ? this.formatGalleryPlacardDate(exifData.dateTime)
+      : null;
     measureCtx.font = `${metaFontSize}px ${sansFamily}`;
     const dateLines = dateText
       ? this.wrapText(measureCtx, dateText, rightColumnWidth)
       : [];
-    const locationText = exifData.location ?? null;
+    const locationText = includeRight ? (exifData.location ?? null) : null;
     const locationLines = locationText
       ? this.wrapText(measureCtx, locationText, rightColumnWidth)
       : [];
@@ -2784,6 +2912,65 @@ export class CanvasRenderer {
         y += layout.metaLineHeight;
       }
       ctx.restore();
+    }
+
+    ctx.restore();
+  }
+
+  private static drawGalleryPlacardPanel(
+    ctx: CanvasRenderingContext2D,
+    template: Template,
+    exifData: NormalizedExifData,
+    scaleFactor: number,
+    panelX: number,
+    panelY: number,
+    panelWidth: number,
+    panelHeight: number,
+    sections: GalleryPlacardSection
+  ): void {
+    if (panelWidth <= 0 || panelHeight <= 0) return;
+
+    const { style } = template;
+    const layout = this.buildGalleryPlacardLayout(
+      template,
+      exifData,
+      scaleFactor,
+      panelWidth,
+      ctx,
+      { forceStacked: true, sections }
+    );
+
+    ctx.save();
+    ctx.globalAlpha = style.opacity;
+    ctx.fillStyle = style.backgroundColor;
+    ctx.fillRect(panelX, panelY, panelWidth, panelHeight);
+    ctx.restore();
+
+    ctx.save();
+    ctx.fillStyle = style.textColor;
+    ctx.textBaseline = 'alphabetic';
+    ctx.shadowColor = 'transparent';
+    ctx.shadowBlur = 0;
+    ctx.shadowOffsetX = 0;
+    ctx.shadowOffsetY = 0;
+
+    const contentTop = panelY + (panelHeight - layout.contentHeight) / 2;
+    const leftX = panelX + layout.paddingX;
+
+    let cursorY = contentTop;
+    if (sections !== 'right-only') {
+      this.drawGalleryPlacardLeftColumn(ctx, layout, leftX, cursorY);
+      cursorY += layout.leftHeight;
+      if (
+        sections === 'all' &&
+        layout.leftHeight > 0 &&
+        layout.rightHeight > 0
+      ) {
+        cursorY += layout.interSectionGap;
+      }
+    }
+    if (sections !== 'left-only') {
+      this.drawGalleryPlacardRightColumn(ctx, layout, leftX, cursorY);
     }
 
     ctx.restore();
@@ -3092,9 +3279,21 @@ export class CanvasRenderer {
     template: Template,
     exifData: NormalizedExifData,
     baseWidth: number,
-    baseHeight: number
+    baseHeight: number,
+    overlayPosition: PositionPreset = 'bottom-left'
   ): number {
     if (template.layout !== 'bottom-padding') return 0;
+    const galleryMode = this.resolveGalleryPlacardMode(
+      template,
+      overlayPosition
+    );
+    if (
+      galleryMode === 'left' ||
+      galleryMode === 'right' ||
+      galleryMode === 'split'
+    ) {
+      return 0;
+    }
     const scaleFactor = Math.min(baseWidth, baseHeight) / 1000;
     return this.calculateDynamicTemplateHeight(
       template,
@@ -3102,6 +3301,24 @@ export class CanvasRenderer {
       scaleFactor,
       baseWidth
     );
+  }
+
+  // Side padding contributed by the gallery-placard template when its overlay
+  // position selects a side or split mode. Mirrors the canvas extension done
+  // inside render(), so the preview hook can size its canvas correctly.
+  static estimateGalleryPlacardSidePadding(
+    template: Template,
+    baseWidth: number,
+    overlayPosition: PositionPreset
+  ): { leftPad: number; rightPad: number } {
+    const mode = this.resolveGalleryPlacardMode(template, overlayPosition);
+    if (!mode || mode === 'bottom') return { leftPad: 0, rightPad: 0 };
+    const isSplit = mode === 'split';
+    const width = this.getGalleryPlacardSidePanelWidth(baseWidth, isSplit);
+    return {
+      leftPad: mode === 'left' || mode === 'split' ? width : 0,
+      rightPad: mode === 'right' || mode === 'split' ? width : 0,
+    };
   }
 
   // Half-step (pyramid) downsample: keep halving the source onto an

--- a/src/templates/__tests__/galleryPlacard.test.ts
+++ b/src/templates/__tests__/galleryPlacard.test.ts
@@ -89,4 +89,54 @@ describe('galleryPlacardTemplate', () => {
       )
     ).not.toThrow();
   });
+
+  it('returns no side padding for the bottom-left default position', () => {
+    const pad = CanvasRenderer.estimateGalleryPlacardSidePadding(
+      galleryPlacardTemplate,
+      1200,
+      'bottom-left'
+    );
+    expect(pad).toEqual({ leftPad: 0, rightPad: 0 });
+  });
+
+  it('reports left-side padding only when overlay position is top-left', () => {
+    const pad = CanvasRenderer.estimateGalleryPlacardSidePadding(
+      galleryPlacardTemplate,
+      1200,
+      'top-left'
+    );
+    expect(pad.leftPad).toBeGreaterThan(0);
+    expect(pad.rightPad).toBe(0);
+  });
+
+  it('reports right-side padding only when overlay position is top-right', () => {
+    const pad = CanvasRenderer.estimateGalleryPlacardSidePadding(
+      galleryPlacardTemplate,
+      1200,
+      'top-right'
+    );
+    expect(pad.leftPad).toBe(0);
+    expect(pad.rightPad).toBeGreaterThan(0);
+  });
+
+  it('reports padding on both sides for the split layout (bottom-right)', () => {
+    const pad = CanvasRenderer.estimateGalleryPlacardSidePadding(
+      galleryPlacardTemplate,
+      1200,
+      'bottom-right'
+    );
+    expect(pad.leftPad).toBeGreaterThan(0);
+    expect(pad.rightPad).toBeGreaterThan(0);
+  });
+
+  it('skips bottom padding when a side mode is active', () => {
+    const h = CanvasRenderer.estimateBottomPaddingHeight(
+      galleryPlacardTemplate,
+      fullExif,
+      1200,
+      1600,
+      'top-left'
+    );
+    expect(h).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
- Gallery Placard で Overlay Position に応じてメタデータの配置を切り替えできるようにした
- 縦構図向けに、画像の左 / 右へ単独パネルを描画する 2 モードと、左右両側に分割描画するスプリットモードを追加
- 既存の下部プラカード（Bottom Left）はデフォルトとして維持

### Overlay Position マッピング
- **Bottom Left ↙️**: 既存の下部プラカード（変更なし）
- **Top Left ↖️**: 画像左に余白を追加し、すべてのメタデータを縦に積む
- **Top Right ↗️**: 画像右に余白を追加し、すべてのメタデータを縦に積む
- **Bottom Right ↘️**: 左右に余白を追加し、左に Make/Model/Lens、右に Exposure/Date/Location を分割描画

### 主な実装
- `buildGalleryPlacardLayout` に `forceStacked` / `sections` オプションを追加し、片側のみの内容生成に対応
- 画像オフセット + サイドパネル描画のため `render()` を分岐
- プレビューサイズ推定が左右余白を考慮するよう `estimateBottomPaddingHeight` を拡張し、`estimateGalleryPlacardSidePadding` を新設

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npx vitest run`（87/87 パス、サイドモード/スプリットモードのテスト追加）
- [x] `npm run build`
- [ ] ブラウザで Overlay Position を切り替えてサイド/スプリット表示を目視確認（縦構図写真）
- [ ] サイドパネル幅 (`getGalleryPlacardSidePanelWidth`) が縦構図と横構図でバランス良いか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)