### PR TITLE
docs: refresh README/CLAUDE.md and add MIT LICENSE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+MetaMark is a client-side web app that adds EXIF metadata overlays to photos. All image processing happens in the browser (privacy-first). Deployed as a static site on Cloudflare Workers at metamark.kiakiraki.dev.
+
+## Commands
+
+```bash
+npm run dev              # Dev server (Turbopack) at http://localhost:3000
+npm run build            # Static export to dist/
+npm run preview          # Serve dist/ locally on port 3000
+npm run lint             # ESLint
+npm run format           # Prettier (write)
+npm run format:check     # Prettier (check only, used in CI)
+npx tsc --noEmit         # Type check
+npm test                 # Vitest (single run)
+npm run test:watch       # Vitest (watch mode)
+npm run deploy           # Deploy to Cloudflare Workers (production)
+npm run deploy:preview   # Deploy to Cloudflare Workers (preview)
+```
+
+Run a single test file: `npx vitest run src/services/__tests__/canvasRenderer.test.ts`
+Run a single test by name: `npx vitest run -t "scales down landscape"`
+
+Tests use Vitest with `jsdom` and globals enabled (see `vitest.config.ts`); `@testing-library/react` is available. Tests live alongside the code they cover under `__tests__/` folders, currently in `src/services/`, `src/stores/`, `src/hooks/`, and `src/templates/`.
+
+CI runs: lint → format:check → tsc --noEmit → test → build.
+
+## Architecture
+
+**Stack**: Next.js (App Router, static export) / React 19 / TypeScript / Tailwind CSS v4 / Zustand / Cloudflare Workers
+
+### Key Layers
+
+- **`src/app/`** — Single-page app (`page.tsx` is the only route). Layout pins the theme to dark (`<html className="dark">`) and wires the font CSS variables from `@/styles/fonts`.
+- **`src/components/`** — UI split into `workspace/` (image preview, drag-and-drop canvas, right-click `PreviewContextMenu`), `editor/` (`TemplateSelector`, `PositionSelector`, `LensOverrideField`, `LocationOverrideField`), `export/` (format/quality/download controls), `ui/` (toast container). Top-level `ErrorBoundary.tsx` wraps the workspace.
+- **`src/services/`** — Pure business logic, no React dependencies:
+  - `exifExtractor.ts` — Reads EXIF via exifr and normalizes to display strings (ja-JP locale for dates). Routes Sony bodies through `cameraNameFormatter`.
+  - `cameraNameFormatter.ts` — Rewrites Sony ILCE/ILCA/DSC model codes into the marketing α-series names (e.g. `ILCE-7M4` → `α7 IV`).
+  - `canvasRenderer.ts` — Canvas drawing with dynamic height calculation, text wrapping, responsive font scaling, 4K support. Dispatches per-template rendering via the template's `customDraw` (`caption`, `technical`, `compact`, `imprint`, `gallery-placard`); the film template auto-rotates for portrait images.
+  - `imageProcessor.ts` — File validation (JPEG/PNG/HEIC, max 20MB), Blob URL lifecycle.
+- **`src/stores/`** — Zustand stores. No cross-store dependencies.
+  - `imageStore` / `templateStore` — selected image and template preset.
+  - `exifStore` — raw + normalized EXIF, plus per-image `lensOverrides` / `locationOverrides` exposed via `getEffectiveNormalizedData`.
+  - `settingsStore` — `persist`-backed canvas settings plus template tweaks (`captionInvert`, `galleryPlacardInvert`, `imprintColor`).
+- **`src/hooks/`** — Custom React hooks bridging stores/services to components: `useCanvasRenderer`, `useImageUpload`, `useImageExport`, `useResponsiveCanvas`, `usePanZoom` (pinch/scroll zoom + drag with viewport clamping), `useEffectiveTemplate` and `useEffectiveExifData` (apply settings/overrides on top of the selected template/EXIF), `useToast`.
+- **`src/templates/`** — Template definitions exported through `index.ts` as a `Partial<Record<TemplatePreset, Template>>`: `caption`, `compact`, `technical`, `film`, `imprint`, `gallery-placard`. Each exports a `Template` object with style/position/render config; shared field definitions live in `src/templates/shared/baseFields.ts`.
+- **`src/types/`** — Shared TypeScript types for exif, image, template, and canvas.
+- **`src/styles/fonts.ts`** — Centralized font loaders consumed by the layout: Geist Sans/Mono and Besley via `next/font/google`, DotGothic16 self-hosted via `next/font/local` from `src/styles/fonts/DotGothic16-Latin.woff2` (see `docs/font-build-failure.md` — Google Fonts' DotGothic16 fans out into ~120 subset fetches and a single transient failure breaks the build).
+- **`src/worker.ts`** — Cloudflare Worker entry point. Serves static assets from dist/, injects security headers (CSP, HSTS, COOP/COEP), handles SPA fallback to /index.html, and sets cache policies.
+
+### Import Alias
+
+`@/*` maps to `./src/*` (configured in tsconfig.json).
+
+### Build Output
+
+`output: 'export'` in next.config.ts produces fully static HTML in `dist/`. No server-side rendering or API routes.
+
+## Code Style
+
+- Prettier: single quotes, trailing commas (es5), semicolons, 2-space indent, LF line endings.
+- ESLint: next/core-web-vitals + next/typescript + eslint-config-prettier.
+- UI components use Radix UI primitives (Dialog, Select, Slider) for accessibility.
+- Class name composition uses `clsx`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 kiakiraki
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -42,12 +42,14 @@ npm run build
 
 ## 🛠 Tech Stack
 
-- **Framework**: Next.js 15 with App Router
-- **UI**: React 19 + TypeScript + Tailwind CSS
+- **Framework**: Next.js 16 (App Router, static export, Turbopack)
+- **UI**: React 19 + TypeScript + Tailwind CSS v4
+- **Components**: Radix UI primitives (Dialog, Select, Slider)
 - **Animations**: Framer Motion
-- **State Management**: Zustand
+- **State Management**: Zustand (with `persist` for user settings)
 - **EXIF Processing**: exifr
 - **File Upload**: react-dropzone
+- **Testing**: Vitest + Testing Library (jsdom)
 - **Deployment**: Cloudflare Workers
 
 ## 🔧 Configuration
@@ -74,24 +76,30 @@ Security headers are applied in the Worker (`src/worker.ts`), including:
 
 ```
 src/
-├── app/              # Next.js App Router pages
+├── app/              # Next.js App Router (single page + layout)
 ├── components/       # React components
-│   ├── upload/      # File upload components
-│   ├── editor/      # Canvas and template components
-│   └── export/      # Export controls
-├── services/        # Business logic (EXIF, Canvas, etc.)
-├── stores/          # Zustand state management
-├── templates/       # Design templates
-├── types/           # TypeScript definitions
-└── utils/           # Utility functions
+│   ├── workspace/    # Image preview, drag & drop, context menu
+│   ├── editor/       # Template/position selectors, lens & location overrides
+│   ├── export/       # Export controls
+│   ├── ui/           # Toast container
+│   └── ErrorBoundary.tsx
+├── hooks/            # Custom React hooks (canvas, upload, pan/zoom, export, toast, ...)
+├── services/         # Business logic (EXIF extraction, canvas rendering, image I/O)
+├── stores/           # Zustand state management
+├── templates/        # Overlay template definitions
+├── types/            # TypeScript definitions
+├── styles/           # Font loaders + bundled DotGothic16 woff2
+└── worker.ts         # Cloudflare Worker entry (static assets + security headers)
 ```
 
 ## 🎨 Templates
 
-- **Caption**: Black footer bar
+- **Caption**: Footer bar with optional invert
 - **Compact**: 2×2 frosted info card
-- **Technical**: Detailed specs (monospaced)
-- **Film**: Retro film-camera date imprint
+- **Technical**: Detailed specs with iconography (monospaced)
+- **Film**: Retro film-camera date imprint (auto-rotates for portrait)
+- **Imprint**: Frameless EXIF text printed directly on the photo (white/black)
+- **Gallery Placard**: Museum-style bottom placard with refined typography (with optional invert)
 
 ## 📋 Requirements
 
@@ -110,6 +118,8 @@ src/
 ## 📄 License
 
 MIT License - see [LICENSE](LICENSE) for details.
+
+The bundled DotGothic16 font (`src/styles/fonts/DotGothic16-Latin.woff2`) is distributed under the SIL Open Font License 1.1; see [`src/styles/fonts/DotGothic16-OFL.txt`](src/styles/fonts/DotGothic16-OFL.txt).
 
 ## 🚀 Deployment
 
@@ -154,16 +164,15 @@ This project is configured for deployment to Cloudflare Workers with custom doma
 ✅ **Completed Features**:
 
 - Image upload with drag & drop
-- EXIF metadata extraction
-- Template system (Caption, Compact, Technical, Film)
-- Canvas rendering with overlays
-- High-quality image export
-- Responsive UI with dark/light themes
+- EXIF metadata extraction with Sony α-series model name normalization
+- Lens / location manual overrides
+- Template system (Caption, Compact, Technical, Film, Imprint, Gallery Placard)
+- Canvas rendering with overlays, pan & zoom preview, right-click context menu
+- High-quality image export (PNG/JPEG, quality control)
 - Static site generation for Cloudflare Workers
 
 🔄 **Coming Next**:
 
-- Additional templates (Film, Technical)
 - Custom template editor
 - Batch processing
 - RAW image support

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "metamark",
   "version": "0.1.0",
   "private": true,
+  "license": "MIT",
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",


### PR DESCRIPTION
## Summary

- Update `README.md` and `CLAUDE.md` to match the current codebase: theme is dark-pinned (no `ThemeContext`), template lineup is six entries including `imprint` and `gallery-placard`, `customDraw` dispatch, lens/location overrides in `exifStore`, persisted `settingsStore` tweaks (caption invert, gallery-placard invert, imprint color), Sony α-series model name normalization, self-hosted DotGothic16, expanded test layout, Next.js 16 / Tailwind v4 / Vitest in the stack list, and a corrected `src/` tree.
- Add a real `LICENSE` (MIT, Copyright 2025-2026 kiakiraki) so the existing README link resolves, and set `"license": "MIT"` in `package.json`.
- Note the SIL OFL 1.1 attribution for the bundled DotGothic16 font in the README license section.

Out of scope: untracked WIP files in the working tree (`docs/`, `src/components/workspace/PreviewContextMenu.tsx`, `src/hooks/useImageExport.ts`, `src/hooks/usePanZoom.ts`, `src/hooks/__tests__/`) are intentionally not staged.

## Test plan

- [ ] Confirm rendered README on GitHub: License section links resolve, template list matches the actual presets, project structure tree matches `src/`.
- [ ] `cat LICENSE` — verify MIT text and copyright holder name are acceptable (swap `kiakiraki` for the real name if preferred).
- [ ] `npm run lint && npx tsc --noEmit && npm test && npm run build` to confirm nothing else regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)