### PR TITLE
fix: apply HSTS, film template font, and Tailwind v4 opacity classes

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,4 +1,5 @@
 /*
+  Strict-Transport-Security: max-age=31536000; includeSubDomains
   X-Frame-Options: DENY
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin

--- a/src/components/workspace/ImageWorkspace.tsx
+++ b/src/components/workspace/ImageWorkspace.tsx
@@ -103,10 +103,9 @@ export function ImageWorkspace() {
           'relative w-full rounded-xl overflow-hidden transition-all duration-300',
           'flex justify-center bg-gray-100 dark:bg-gray-700',
           {
-            'ring-2 ring-blue-400 ring-opacity-50 dark:ring-blue-500':
+            'ring-2 ring-blue-400/50 dark:ring-blue-500/50':
               isDragActive && !isDragReject,
-            'ring-2 ring-red-400 ring-opacity-50 dark:ring-red-500':
-              isDragReject,
+            'ring-2 ring-red-400/50 dark:ring-red-500/50': isDragReject,
           }
         )}
         style={{
@@ -132,7 +131,7 @@ export function ImageWorkspace() {
 
         {/* Processing Overlay */}
         {(isRendering || currentImage.isProcessing) && (
-          <div className="absolute inset-0 bg-black bg-opacity-50 rounded-xl flex items-center justify-center">
+          <div className="absolute inset-0 bg-black/50 rounded-xl flex items-center justify-center">
             <div className="text-white text-center space-y-3">
               <div className="animate-spin w-8 h-8 border-2 border-white border-t-transparent rounded-full mx-auto"></div>
               <p className="font-medium">
@@ -144,7 +143,7 @@ export function ImageWorkspace() {
 
         {/* Drag Overlay */}
         {isDragActive && (
-          <div className="absolute inset-0 bg-blue-600 bg-opacity-90 rounded-xl flex items-center justify-center">
+          <div className="absolute inset-0 bg-blue-600/90 rounded-xl flex items-center justify-center">
             <div className="text-center text-white space-y-4">
               <div className="text-6xl">📥</div>
               <p className="text-xl font-bold">
@@ -176,7 +175,7 @@ export function ImageWorkspace() {
       </AnimatePresence>
 
       {/* Image Info Bar */}
-      <div className="absolute bottom-4 left-4 bg-black bg-opacity-75 dark:bg-gray-900 dark:bg-opacity-90 text-white px-4 py-2 rounded-lg text-sm">
+      <div className="absolute bottom-4 left-4 bg-black/75 dark:bg-gray-900/90 text-white px-4 py-2 rounded-lg text-sm">
         <div className="flex items-center space-x-4">
           <span className="font-medium">{currentImage.name}</span>
           <span>

--- a/src/templates/film.ts
+++ b/src/templates/film.ts
@@ -1,4 +1,5 @@
 import type { Template } from '@/types/template';
+import { dotGothic } from '@/styles/fonts';
 
 // Format to classic film date imprint like "'98.12.05"
 function formatFilmDate(value: string | null): string {
@@ -31,7 +32,7 @@ export const filmTemplate: Template = {
   description: 'Retro film-camera date imprint style',
   style: {
     // Dot-matrix feel for film date imprint
-    fontFamily: "'DotGothic16', 'Courier New', monospace",
+    fontFamily: `${dotGothic.style.fontFamily}, 'Courier New', monospace`,
     fontSize: 30,
     // Amber/orange LED-like color
     textColor: '#ff6a00',
@@ -48,7 +49,7 @@ export const filmTemplate: Template = {
     height: 40,
     alignment: 'left',
   },
-  fontRequirements: [{ family: 'DotGothic16' }],
+  fontRequirements: [{ family: dotGothic.style.fontFamily }],
   positionOverride: (isPortrait) => (isPortrait ? 'top-right' : 'bottom-right'),
   textShadow: true,
   rotateForPortrait: true,


### PR DESCRIPTION
## Summary

コードベース全体レビュー（`docs/code-review-2026-06-11.md`、未コミット）で見つかった「即日修正・無リスク」3件の修正です。いずれも**コードは存在するが実際には効いていなかった**もの。

### 1. HSTS 追加（`public/_headers`）
本番の実測で、レスポンスヘッダーは `worker.ts` ではなく `public/_headers` 由来であることを確認（`wrangler.toml` に `run_worker_first` がないため、アセットに一致するリクエストは Worker を経由しない）。現状 HSTS が一切配信されていないため、実際に効いている `_headers` に `Strict-Transport-Security: max-age=31536000; includeSubDomains` を追加。

### 2. Film テンプレートのフォント修正（`src/templates/film.ts`）
film だけリテラル文字列 `'DotGothic16'` を指定していたが、`next/font/local` が生成する @font-face のファミリ名は `dotGothic`（ハッシュ化された別名）であり一致しない。そのため `fonts.load()` は何もロードせず、Canvas 描画は `'Courier New'` にフォールバックしていた。caption.ts 等と同じ `dotGothic.style.fontFamily` 参照に変更。

### 3. Tailwind v4 で削除された opacity ユーティリティの移行（`ImageWorkspace.tsx`）
`bg-opacity-*` / `ring-opacity-*` は Tailwind v4 で削除済みで、ビルド済みCSSに一切生成されていなかった。レンダリング中オーバーレイとドラッグオーバーレイが半透明にならず画像を完全に隠していたため、スラッシュ記法（`bg-black/50` 等）5箇所に移行。v3 時代の意図（dark 側も 50% 透過）を維持。

## Verification

- lint / format:check / tsc / test（96件）/ build すべて通過
- ビルド成果物で実効性を確認:
  - 生成CSSに `bg-black\/50` `bg-blue-600\/90` `bg-black\/75` `ring-{blue,red}-{400,500}\/50` が存在
  - `dotGothic` の @font-face とテンプレートの参照ファミリ名が一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)