### PR TITLE
fix: deterministic export resolution and async race fixes

### DIFF
--- a/src/components/export/ExportControls.tsx
+++ b/src/components/export/ExportControls.tsx
@@ -3,22 +3,20 @@
 import { useState } from 'react';
 import { motion } from 'framer-motion';
 import { useSelectedImage } from '@/stores/imageStore';
-import { useExifStore } from '@/stores/exifStore';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { CanvasRenderer } from '@/services/canvasRenderer';
 import { ImageProcessor } from '@/services/imageProcessor';
 import clsx from 'clsx';
 import { useToast } from '@/hooks/useToast';
 import { useEffectiveTemplate } from '@/hooks/useEffectiveTemplate';
+import { useEffectiveExifData } from '@/hooks/useEffectiveExifData';
 
 export function ExportControls() {
   const [isExporting, setIsExporting] = useState(false);
   const toast = useToast();
 
   const selectedImage = useSelectedImage();
-  const getEffectiveNormalizedData = useExifStore(
-    (state) => state.getEffectiveNormalizedData
-  );
+  const exifData = useEffectiveExifData(selectedImage?.id);
   const selectedTemplate = useEffectiveTemplate();
   const canvasSettings = useSettingsStore((state) => state.canvasSettings);
   const updateCanvasSettings = useSettingsStore(
@@ -26,17 +24,12 @@ export function ExportControls() {
   );
 
   const handleExport = async () => {
-    if (!selectedImage || !selectedTemplate) return;
+    if (!selectedImage || !selectedTemplate || !exifData) return;
 
     setIsExporting(true);
 
     try {
       const image = await ImageProcessor.createImageElement(selectedImage.url);
-      const exifData = getEffectiveNormalizedData(selectedImage.id);
-
-      if (!exifData) {
-        throw new Error('No EXIF data available');
-      }
 
       // Create temporary canvas for export
       const canvas = document.createElement('canvas');
@@ -57,6 +50,9 @@ export function ExportControls() {
           width,
           height,
         },
+        // Keep the exported resolution independent of the display the app
+        // runs on; calculateOptimalSize already caps the output at 4K.
+        devicePixelRatio: 1,
       });
 
       const url = URL.createObjectURL(blob);
@@ -82,7 +78,10 @@ export function ExportControls() {
     }
   };
 
-  const canExport = selectedImage && selectedTemplate;
+  // exifData is undefined while extraction is still in flight; images
+  // without EXIF still resolve to an all-null NormalizedExifData, so this
+  // only blocks the brief extraction window after an upload.
+  const canExport = selectedImage && selectedTemplate && exifData;
 
   return (
     <div className="space-y-6">
@@ -151,9 +150,11 @@ export function ExportControls() {
             ? 'Select an image first'
             : !selectedTemplate
               ? 'Choose a template first'
-              : isExporting
-                ? 'Exporting...'
-                : 'Download image with overlay'
+              : !exifData
+                ? 'Reading image metadata...'
+                : isExporting
+                  ? 'Exporting...'
+                  : 'Download image with overlay'
         }
         className={clsx(
           'w-full py-3 px-4 rounded-lg font-medium text-center transition-colors',
@@ -174,9 +175,10 @@ export function ExportControls() {
       <div className="text-xs text-gray-500 space-y-1">
         {!selectedImage && <p>• Select an image to export</p>}
         {selectedImage && !selectedTemplate && <p>• Choose a template</p>}
-        {selectedImage && selectedTemplate && (
-          <p className="text-green-600">✓ Ready to export</p>
+        {selectedImage && selectedTemplate && !exifData && (
+          <p>• Reading image metadata...</p>
         )}
+        {canExport && <p className="text-green-600">✓ Ready to export</p>}
       </div>
     </div>
   );

--- a/src/hooks/useCanvasRenderer.ts
+++ b/src/hooks/useCanvasRenderer.ts
@@ -99,13 +99,23 @@ export function useCanvasRenderer(currentImage: ProcessedImage | null) {
   );
 
   useEffect(() => {
+    // Re-runs of this effect must not let an older in-flight render finish
+    // after a newer one: the slower run would draw a stale image/template
+    // onto the canvas, and its `finally` would clear isRendering while the
+    // newer render is still working.
+    let cancelled = false;
+
     const renderCanvas = async () => {
-      if (!currentImage || !selectedTemplate || !canvasRef.current) return;
+      if (!currentImage || !selectedTemplate || !canvasRef.current) {
+        setIsRendering(false);
+        return;
+      }
 
       setIsRendering(true);
 
       try {
         const image = await ImageProcessor.createImageElement(currentImage.url);
+        if (cancelled) return;
 
         const exifData = currentExifData ?? PLACEHOLDER_EXIF_DATA;
         const { width: renderWidth, height: renderHeight } =
@@ -128,16 +138,24 @@ export function useCanvasRenderer(currentImage: ProcessedImage | null) {
             height: renderHeight,
           },
         });
+        if (cancelled) return;
         updateCanvasDisplaySize();
       } catch (error: unknown) {
-        console.error('Error rendering canvas:', error);
+        if (!cancelled) {
+          console.error('Error rendering canvas:', error);
+        }
       } finally {
-        setIsRendering(false);
+        if (!cancelled) {
+          setIsRendering(false);
+        }
       }
     };
 
     const timer = setTimeout(renderCanvas, 50);
-    return () => clearTimeout(timer);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
   }, [
     currentImage,
     selectedTemplate,

--- a/src/hooks/useImageUpload.ts
+++ b/src/hooks/useImageUpload.ts
@@ -43,6 +43,13 @@ export function useImageUpload() {
 
       try {
         const imageFile = await ImageProcessor.loadImageFile(file);
+        // A later drop may have aborted this one while the file was decoding;
+        // landing setImage here would replace the newer image with this stale
+        // one (and its EXIF extraction below would be skipped as aborted).
+        if (signal.aborted) {
+          ImageProcessor.cleanupImageUrl(imageFile.url);
+          return;
+        }
         setImage(imageFile);
 
         extractExifData(file)
@@ -58,6 +65,7 @@ export function useImageUpload() {
             toast.error('Failed to extract EXIF data.');
           });
       } catch (error: unknown) {
+        if (signal.aborted) return;
         console.error('Error loading image:', error);
         toast.error('Failed to load image.');
       }

--- a/src/services/canvasRenderer.ts
+++ b/src/services/canvasRenderer.ts
@@ -262,7 +262,7 @@ let galleryPlacardLayoutCache: {
 } | null = null;
 
 export class CanvasRenderer {
-  static async render(options: RenderOptions): Promise<string> {
+  static async render(options: RenderOptions): Promise<void> {
     const { canvas, image, template, exifData, settings } = options;
     const ctx = canvas.getContext('2d');
 
@@ -272,7 +272,8 @@ export class CanvasRenderer {
 
     // Get device pixel ratio for high-DPI displays
     const devicePixelRatio =
-      typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
+      options.devicePixelRatio ??
+      (typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1);
 
     const baseWidth = settings.width;
     const baseHeight = settings.height;
@@ -465,12 +466,6 @@ export class CanvasRenderer {
         overlayPosition: effectiveSettings.overlayPosition,
       });
     }
-
-    // Return as data URL
-    return canvas.toDataURL(
-      settings.format === 'png' ? 'image/png' : 'image/jpeg',
-      settings.quality
-    );
   }
 
   private static calculateDynamicPosition(

--- a/src/types/canvas.ts
+++ b/src/types/canvas.ts
@@ -15,4 +15,7 @@ export interface RenderOptions {
   template: import('./template').Template;
   exifData: import('./exif').NormalizedExifData;
   settings: CanvasSettings;
+  // Defaults to window.devicePixelRatio. Pass 1 for exports so the output
+  // resolution does not depend on the display the app happens to run on.
+  devicePixelRatio?: number;
 }


### PR DESCRIPTION
## Summary

レビュー（`docs/code-review-2026-06-11.md`）の優先度②、エクスポート品質とレース対策です。H-1 / H-5 / H-3 / H-4 / M-16 に対応。

### エクスポート解像度の決定論化（H-1）
`RenderOptions` に `devicePixelRatio` を追加し、エクスポート経路では `1` を明示。これまでは常に `window.devicePixelRatio` が乗算されており、DPR=2 のディスプレイでは `calculateOptimalSize` の 4K 上限を超えて最大 8192px が出力されていた（= 出力解像度が「どの画面で操作したか」で変わる）。プレビュー経路は従来どおり DPR を使用。

### 無駄な dataURL エンコードの除去（H-5）
`CanvasRenderer.render()` は末尾で必ず `toDataURL()` を実行していたが、**戻り値を使う呼び出し元は存在しない**（grep で確認）。エクスポートでは数十MBの base64 文字列を生成して即捨てた後 `toBlob` で再エンコードしていた。戻り値を `void` に変更。

### EXIF 抽出中のエクスポート失敗を解消（M-16）
ExportControls が EXIF を命令的に読んで `throw` していたのを、`useEffectiveExifData` でリアクティブに購読する形に変更。アップロード直後の抽出中はボタンを disable + 「Reading image metadata...」表示。EXIF を持たない画像は抽出完了後に all-null データでエクスポート可能（従来は謎の「Export failed. Please try again.」）。

### プレビューレンダリングのレース解消（H-3）
`useCanvasRenderer` の effect に `cancelled` フラグを追加。これまでは依存変更時に新旧2つの非同期レンダリングが並走し、遅い方が後勝ちして古い画像/テンプレートでキャンバスを上書き、`finally` が新しいレンダリング中の `isRendering` を消すことがあった。

### アップロードのレース解消（H-4）
`useImageUpload` で `loadImageFile` の await 後に `signal.aborted` をチェック。重い画像のデコード中に2枚目をドロップすると、遅れて解決した古い画像が新しい画像を破棄して表示される（しかも EXIF なしのまま）問題を修正。負けた側の blob URL は revoke。

## Verification

- lint / format:check / tsc / test（96件）/ build すべて通過
- `render()` の戻り値を使う呼び出し元がないことを grep で確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)