### PR TITLE
fix: allow Cloudflare Web Analytics beacon in CSP

### DIFF
--- a/scripts/generate-csp.mjs
+++ b/scripts/generate-csp.mjs
@@ -52,13 +52,15 @@ const scriptHashes = [
 
 const csp = [
   "default-src 'self'",
-  `script-src 'self' ${scriptHashes.join(' ')}`,
+  // Cloudflare Web Analytics injects its beacon script at the edge
+  `script-src 'self' https://static.cloudflareinsights.com ${scriptHashes.join(' ')}`,
   // framer-motion sets inline style attributes
   "style-src 'self' 'unsafe-inline'",
   // previews use blob: URLs, icons may use data:
   "img-src 'self' data: blob:",
   "font-src 'self'",
-  "connect-src 'self'",
+  // the analytics beacon posts RUM data to cloudflareinsights.com
+  "connect-src 'self' https://cloudflareinsights.com",
   "object-src 'none'",
   "base-uri 'none'",
   "form-action 'self'",


### PR DESCRIPTION
## Summary

本番のブラウザ実機検証（PR #173 の事後確認）中に、**Cloudflare Web Analytics のビーコンが CSP にブロックされている**ことを発見しました。ビーコンは Cloudflare がエッジで自動注入する外部スクリプトで、PR #172 で CSP を有効化するまでは動いていたため、現状アナリティクスが黙って止まっています。

実測したコンソールエラー:
> Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/...' violates the following Content Security Policy directive: "script-src 'self' 'sha256-...'"

## 変更

`scripts/generate-csp.mjs` の CSP テンプレートに2オリジンを追加:
- `script-src` に `https://static.cloudflareinsights.com`（ビーコン本体）
- `connect-src` に `https://cloudflareinsights.com`（RUM データの送信先）

## Verification

- ビルド後の `dist/_headers` に両ディレクティブが反映されることを確認
- lint / format:check 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)