### PR TITLE
fix: correct EXIF shutter speed, dateTime field, and ILCE-7CR handling

### DIFF
--- a/src/services/__tests__/cameraNameFormatter.test.ts
+++ b/src/services/__tests__/cameraNameFormatter.test.ts
@@ -13,6 +13,7 @@ describe('formatSonyModel', () => {
       ['ILCE-7C', 'α7C'],
       ['ILCE-6700', 'α6700'],
       ['ILCE-9M3', 'α9 III'],
+      ['ILCE-7CR', 'α7CR'],
     ])('%s → %s', (input, expected) => {
       expect(formatSonyModel('SONY', input)).toBe(expected);
     });

--- a/src/services/__tests__/exifExtractor.test.ts
+++ b/src/services/__tests__/exifExtractor.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeExifData } from '../exifExtractor';
+import {
+  normalizeExifData,
+  calculateShutterSpeed,
+  formatDateTime,
+} from '../exifExtractor';
 import type { ExifData } from '@/types/exif';
 
 describe('normalizeExifData', () => {
@@ -128,5 +132,67 @@ describe('normalizeExifData', () => {
     const result = normalizeExifData(exifData);
     expect(result.cameraMake).toBe('Sony');
     expect(result.cameraModel).toBe('A7IV');
+  });
+});
+
+describe('calculateShutterSpeed', () => {
+  it('returns undefined for undefined input', () => {
+    expect(calculateShutterSpeed(undefined)).toBeUndefined();
+  });
+
+  it('formats long exposures as plain seconds (>= 1s)', () => {
+    expect(calculateShutterSpeed(2)).toBe('2s');
+  });
+
+  it('returns 1/2s for exactly 0.5s', () => {
+    expect(calculateShutterSpeed(0.5)).toBe('1/2s');
+  });
+
+  it('returns 1/3s for 1/3 (≈0.3333)', () => {
+    expect(calculateShutterSpeed(1 / 3)).toBe('1/3s');
+  });
+
+  it('returns 1/250s for 0.004', () => {
+    expect(calculateShutterSpeed(0.004)).toBe('1/250s');
+  });
+
+  it('returns decimal 0.6s for 0.6 (not 1/2s)', () => {
+    expect(calculateShutterSpeed(0.6)).toBe('0.6s');
+  });
+
+  it('returns decimal 0.8s for 0.8 (not 1/1s)', () => {
+    expect(calculateShutterSpeed(0.8)).toBe('0.8s');
+  });
+});
+
+describe('formatDateTime', () => {
+  it('parses EXIF-format string "2024:06:15 14:30:00"', () => {
+    const result = formatDateTime('2024:06:15 14:30:00');
+    expect(result).not.toBeNull();
+    expect(typeof result).toBe('string');
+    // Should contain the year and not be a raw Date object
+    expect(result).toContain('2024');
+  });
+
+  it('formats a Date instance to a locale string', () => {
+    const d = new Date(2024, 5, 15, 14, 30, 0); // June 15, 2024
+    const result = formatDateTime(d);
+    expect(result).not.toBeNull();
+    expect(typeof result).toBe('string');
+    expect(result).toContain('2024');
+  });
+
+  it('returns null for an invalid Date instance', () => {
+    expect(formatDateTime(new Date('not-a-date'))).toBeNull();
+  });
+
+  it('returns null for undefined input', () => {
+    expect(formatDateTime(undefined)).toBeNull();
+  });
+
+  it('does not throw for an invalid string value', () => {
+    expect(() => formatDateTime('garbage')).not.toThrow();
+    const result = formatDateTime('garbage');
+    expect(typeof result === 'string' || result === null).toBe(true);
   });
 });

--- a/src/services/cameraNameFormatter.ts
+++ b/src/services/cameraNameFormatter.ts
@@ -9,7 +9,7 @@ const ROMAN_MARKS: Record<string, string> = {
   '9': 'IX',
 };
 
-const ILCE_PATTERN = /^ILCE-(\d+)([RSC])?(?:M(\d+))?$/;
+const ILCE_PATTERN = /^ILCE-(\d+)(CR|[RSC])?(?:M(\d+))?$/;
 const ILCA_PATTERN = /^ILCA-(\d+)(?:M(\d+))?$/;
 const DSC_PATTERN = /^DSC-([A-Z]+\d+[A-Z]*?)(?:M(\d+))?$/;
 

--- a/src/services/exifExtractor.ts
+++ b/src/services/exifExtractor.ts
@@ -2,15 +2,27 @@ import exifr from 'exifr';
 import type { ExifData, NormalizedExifData } from '@/types/exif';
 import { formatSonyModel } from './cameraNameFormatter';
 
-function calculateShutterSpeed(exposureTime?: number): string | undefined {
+export function calculateShutterSpeed(
+  exposureTime?: number
+): string | undefined {
   if (!exposureTime) return undefined;
 
   if (exposureTime >= 1) {
     return `${exposureTime}s`;
-  } else {
-    const denominator = Math.round(1 / exposureTime);
+  }
+
+  const denominator = Math.round(1 / exposureTime);
+  const relativeError = Math.abs(1 / denominator - exposureTime) / exposureTime;
+  if (denominator >= 1 && relativeError <= 0.05) {
     return `1/${denominator}s`;
   }
+
+  // Fall back to decimal notation; avoid rounding to "1.0" or "0.0"
+  let decimal = exposureTime.toFixed(1);
+  if (decimal === '1.0' || decimal === '0.0') {
+    decimal = exposureTime.toFixed(2);
+  }
+  return `${decimal}s`;
 }
 
 function formatCamera(camera?: {
@@ -80,13 +92,26 @@ function formatLocation(iptc?: {
   return parts.join(', ');
 }
 
-function formatDateTime(dateTime?: string): string | null {
+const DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+};
+
+export function formatDateTime(dateTime?: string | Date): string | null {
   if (!dateTime) return null;
 
   try {
-    const date = new Date(dateTime);
+    // Date instance path — exifr revives some fields as Date objects
+    if (dateTime instanceof Date) {
+      if (isNaN(dateTime.getTime())) return null;
+      return dateTime.toLocaleDateString('ja-JP', DATE_FORMAT_OPTIONS);
+    }
 
-    // Check if the date is valid
+    // String path
+    const date = new Date(dateTime);
     if (isNaN(date.getTime())) {
       // Try parsing EXIF date format (YYYY:MM:DD HH:mm:ss)
       const exifMatch = dateTime.match(
@@ -102,27 +127,14 @@ function formatDateTime(dateTime?: string): string | null {
           parseInt(minute),
           parseInt(second)
         );
-
-        return parsedDate.toLocaleDateString('ja-JP', {
-          year: 'numeric',
-          month: '2-digit',
-          day: '2-digit',
-          hour: '2-digit',
-          minute: '2-digit',
-        });
+        return parsedDate.toLocaleDateString('ja-JP', DATE_FORMAT_OPTIONS);
       }
       return dateTime;
     }
 
-    return date.toLocaleDateString('ja-JP', {
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
+    return date.toLocaleDateString('ja-JP', DATE_FORMAT_OPTIONS);
   } catch {
-    return dateTime;
+    return typeof dateTime === 'string' ? dateTime : null;
   }
 }
 
@@ -151,7 +163,7 @@ export async function extractExifData(file: File): Promise<ExifData> {
         shutterSpeed: calculateShutterSpeed(rawExif.ExposureTime),
       },
       metadata: {
-        dateTime: rawExif.DateTime || rawExif.DateTimeOriginal,
+        dateTime: rawExif.DateTimeOriginal || rawExif.ModifyDate,
         gps:
           rawExif.latitude && rawExif.longitude
             ? {

--- a/src/types/exif.ts
+++ b/src/types/exif.ts
@@ -15,7 +15,7 @@ export interface ExifData {
     exposureTime?: number;
   };
   metadata?: {
-    dateTime?: string;
+    dateTime?: string | Date;
     gps?: {
       latitude?: number;
       longitude?: number;


### PR DESCRIPTION
## Summary

2026-06-13 の包括レビューで確認した EXIF 正確性バグ 3 件の修正です（docs/code-review-2026-06-11.md の M-1 / M-2 / M-6 に対応）。

- **シャッター速度 (M-1)**: `calculateShutterSpeed` が 0.5〜1 秒の露光を誤表示していた問題を修正。`1/N` 表記は相対誤差 5% 以内のときのみ使用し、外れる場合は小数表記にフォールバック。修正前は `0.6s → "1/2s"`、`0.8s → "1/1s"` と**誤った撮影情報が画像に焼き込まれていた**
- **dateTime フィールド (M-2)**: exifr は EXIF タグ 0x0132 を `ModifyDate` として出力するため、存在しない `rawExif.DateTime` への参照を `DateTimeOriginal || ModifyDate`（撮影日時優先）に修正。あわせて `formatDateTime` が exifr の revive 済み `Date` インスタンスを受けられるようシグネチャを拡張し、catch 経路で Date オブジェクトが string として漏れる経路（旧レビュー M-3）も封鎖
- **α7CR (M-6)**: `ILCE_PATTERN` のバリアント群を `(CR|[RSC])?` に拡張し、`ILCE-7CR → α7CR` に変換されるよう修正。既存の `ILCE-7C` / `ILCE-7RM5` 等への退行なし（交替の左優先で安全）

## Test plan

- [x] `calculateShutterSpeed` のテスト 7 件追加（0.6s / 0.8s の小数フォールバック、0.5s・1/3・1/250 の分数維持、>=1s、undefined）
- [x] `formatDateTime` のテスト 5 件追加（EXIF 形式文字列、Date インスタンス、Invalid Date、undefined、不正文字列）
- [x] `ILCE-7CR → α7CR` をテーブルテストに追加
- [x] vitest 109 件 / tsc / eslint / prettier すべて pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)