### PR TITLE
fix: load DotGothic16 japanese glyphs for canvas rendering

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,12 +2,15 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './styles/globals.css';
 // Self-hosted fonts (see src/styles/fonts.ts for the matching font-family
-// constants). The film template only draws latin digits/punctuation, so
-// DotGothic16 ships the latin subset alone.
+// constants). DotGothic16 ships the latin subset for ASCII and the japanese
+// subset for CJK glyphs (e.g. location overrides like 東京・浅草). The
+// japanese face is a single ~400KB woff2 gated by unicode-range, so it is
+// only downloaded once Japanese text actually appears.
 import '@fontsource-variable/geist/index.css';
 import '@fontsource-variable/geist-mono/index.css';
 import '@fontsource-variable/besley/index.css';
 import '@fontsource/dotgothic16/latin-400.css';
+import '@fontsource/dotgothic16/japanese-400.css';
 import { App } from './App';
 
 createRoot(document.getElementById('root')!).render(

--- a/src/services/__tests__/canvasRenderer.test.ts
+++ b/src/services/__tests__/canvasRenderer.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { CanvasRenderer } from '../canvasRenderer';
 
 interface FillCall {
@@ -185,5 +185,44 @@ describe('CanvasRenderer.calculateOptimalSize', () => {
     const result = CanvasRenderer.calculateOptimalSize(6000, 4000);
     const resultRatio = result.width / result.height;
     expect(Math.abs(resultRatio - originalRatio)).toBeLessThan(0.01);
+  });
+});
+
+// loadFontCached is exported for testing. jsdom does not ship document.fonts,
+// so each test defines it as a stub. vi.resetModules() + dynamic import gives
+// each test a fresh module-level fontLoadCache so cache tests are independent.
+describe('loadFontCached', () => {
+  let mockLoad: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockLoad = vi.fn().mockResolvedValue([]);
+    Object.defineProperty(document, 'fonts', {
+      value: { load: mockLoad },
+      configurable: true,
+      writable: true,
+    });
+    vi.resetModules();
+  });
+
+  it('passes both spec and text arguments to document.fonts.load', async () => {
+    const { loadFontCached } = await import('../canvasRenderer');
+    await loadFontCached('16px DotGothic16', 'カメラ');
+    expect(mockLoad).toHaveBeenCalledOnce();
+    expect(mockLoad).toHaveBeenCalledWith('16px DotGothic16', 'カメラ');
+  });
+
+  it('deduplicates when the same unique char set is requested (cache hit on reordered text)', async () => {
+    const { loadFontCached } = await import('../canvasRenderer');
+    await loadFontCached('16px DotGothic16', 'ab');
+    await loadFontCached('16px DotGothic16', 'ba');
+    // 'ab' and 'ba' normalise to the same sorted-unique key → only one load call
+    expect(mockLoad).toHaveBeenCalledOnce();
+  });
+
+  it('calls fonts.load again when text contains different characters (cache miss)', async () => {
+    const { loadFontCached } = await import('../canvasRenderer');
+    await loadFontCached('16px DotGothic16', 'abc');
+    await loadFontCached('16px DotGothic16', 'xyz');
+    expect(mockLoad).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/services/canvasRenderer.ts
+++ b/src/services/canvasRenderer.ts
@@ -14,16 +14,24 @@ function getMeasureContext(): CanvasRenderingContext2D | null {
   return measureCtx;
 }
 
-// Font load promise cache to avoid redundant document.fonts.load() calls
+// Font load promise cache to avoid redundant document.fonts.load() calls.
+// The cache key incorporates the sorted unique characters of the text sample
+// so that unicode-range-split fonts (e.g. DotGothic16 japanese slices) load
+// every required slice. Normalising to unique-sorted chars keeps the cache
+// bounded while maximising hit rate for permutations of the same characters.
 const fontLoadCache = new Map<string, Promise<FontFace[]>>();
 
-function loadFontCached(spec: string): Promise<FontFace[]> {
-  const cached = fontLoadCache.get(spec);
+export function loadFontCached(
+  spec: string,
+  text?: string
+): Promise<FontFace[]> {
+  const key = text ? `${spec}|${[...new Set(text)].sort().join('')}` : spec;
+  const cached = fontLoadCache.get(key);
   if (cached) return cached;
   const fonts = typeof document !== 'undefined' ? document.fonts : null;
   if (!fonts?.load) return Promise.resolve([]);
-  const promise = fonts.load(spec);
-  fontLoadCache.set(spec, promise);
+  const promise = text ? fonts.load(spec, text) : fonts.load(spec);
+  fontLoadCache.set(key, promise);
   return promise;
 }
 
@@ -380,9 +388,16 @@ export class CanvasRenderer {
     );
     ctx.drawImage(drawableSource, drawX, drawY, drawWidth, drawHeight);
 
-    // Load required fonts declared by the template
+    // Load required fonts declared by the template.
+    // Build a sample text from all non-null exif values so that
+    // unicode-range-split fonts (e.g. DotGothic16 japanese slices) pre-load
+    // the correct subset before the canvas draw calls below.
     if (template.fontRequirements?.length) {
       try {
+        const sampleText =
+          Object.values(exifData)
+            .filter((v): v is string => typeof v === 'string' && v.length > 0)
+            .join('') || undefined;
         const baseFontSize = Math.max(
           12,
           template.style.fontSize * scaleFactor
@@ -396,7 +411,10 @@ export class CanvasRenderer {
                   ? Math.max(baseFontSize * 1.6, baseFontSize + 6)
                   : baseFontSize;
               const prefix = w !== 400 ? `${w} ` : '';
-              return loadFontCached(`${prefix}${fontSize}px ${req.family}`);
+              return loadFontCached(
+                `${prefix}${fontSize}px ${req.family}`,
+                sampleText
+              );
             })
           );
         });


### PR DESCRIPTION
## Summary

2026-06-13 レビューの新規発見の修正です。film テンプレートのドットフォント（DotGothic16）が **latin サブセットしか配信されておらず**、日本語テキスト（ロケーション/レンズのオーバーライド等）が Canvas 上で Courier New にフォールバックしていました。

修正は2段構えです：

1. **`japanese-400.css` の import 追加** — japanese フェイスは unicode-range でゲートされた単一の woff2（約400KB）で、日本語グリフが実際に登場するまでダウンロードされません（英語のみの利用では従来どおりゼロコスト）
2. **`document.fonts.load()` に描画テキストを渡す** — text 引数なしの `fonts.load(spec)` はスペース1文字で照合するため、unicode-range フェイスは永遠にロードされず Canvas 描画に間に合いません。`render()` で EXIF の全文字列値から sample text を構築して渡すようにし、`loadFontCached` のキャッシュキーは「ユニーク文字の sorted 集合」で正規化（同じ文字集合の並べ替えはキャッシュヒット）

## Test plan

- [x] `loadFontCached` のテスト3件追加（spec+text の伝達 / 同一文字集合のキャッシュヒット / 異なる文字集合のキャッシュミス）。jsdom に `document.fonts` がないため stub + `vi.resetModules()` で分離
- [x] ビルド成果物に `dotgothic16-japanese-400-normal-*.woff2` が含まれることを確認
- [x] vitest 99件 / tsc / eslint / prettier / build + CSP 検証すべて pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)