### PR TITLE
fix: a11y — announce toasts to screen readers, honor prefers-reduced-motion

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { MotionConfig } from 'framer-motion';
 import { ImageWorkspace } from '@/components/workspace/ImageWorkspace';
 import { TemplateSelector } from '@/components/editor/TemplateSelector';
 import { LensOverrideField } from '@/components/editor/LensOverrideField';
@@ -8,49 +9,51 @@ import { ErrorBoundary } from '@/components/ErrorBoundary';
 
 export function App() {
   return (
-    <main className="min-h-screen bg-gray-100 dark:bg-gray-900 transition-colors">
-      <div className="container mx-auto px-4 py-8">
-        <header className="mb-8 text-center">
-          <h1 className="text-4xl font-bold text-gray-900 dark:text-gray-100 mb-2">
-            MetaMark
-          </h1>
-          <p className="text-lg text-gray-600 dark:text-gray-400">
-            Add beautiful EXIF metadata overlays to your photos
-          </p>
-        </header>
+    <MotionConfig reducedMotion="user">
+      <main className="min-h-screen bg-gray-100 dark:bg-gray-900 transition-colors">
+        <div className="container mx-auto px-4 py-8">
+          <header className="mb-8 text-center">
+            <h1 className="text-4xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+              MetaMark
+            </h1>
+            <p className="text-lg text-gray-600 dark:text-gray-400">
+              Add beautiful EXIF metadata overlays to your photos
+            </p>
+          </header>
 
-        <div className="grid grid-cols-1 lg:grid-cols-4 gap-6 max-w-7xl mx-auto">
-          {/* Main Workspace */}
-          <div className="lg:col-span-3">
-            <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6 h-full transition-colors">
-              <ErrorBoundary>
-                <ImageWorkspace />
-              </ErrorBoundary>
-            </div>
-          </div>
-
-          {/* Controls Sidebar */}
-          <div className="lg:col-span-1 space-y-6">
-            <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6 transition-colors">
-              <TemplateSelector />
+          <div className="grid grid-cols-1 lg:grid-cols-4 gap-6 max-w-7xl mx-auto">
+            {/* Main Workspace */}
+            <div className="lg:col-span-3">
+              <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6 h-full transition-colors">
+                <ErrorBoundary>
+                  <ImageWorkspace />
+                </ErrorBoundary>
+              </div>
             </div>
 
-            <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6 transition-colors">
-              <LensOverrideField />
-            </div>
+            {/* Controls Sidebar */}
+            <div className="lg:col-span-1 space-y-6">
+              <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6 transition-colors">
+                <TemplateSelector />
+              </div>
 
-            <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6 transition-colors">
-              <LocationOverrideField />
-            </div>
+              <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6 transition-colors">
+                <LensOverrideField />
+              </div>
 
-            <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6 transition-colors">
-              <ExportControls />
+              <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6 transition-colors">
+                <LocationOverrideField />
+              </div>
+
+              <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6 transition-colors">
+                <ExportControls />
+              </div>
             </div>
           </div>
         </div>
-      </div>
 
-      <ToastContainer />
-    </main>
+        <ToastContainer />
+      </main>
+    </MotionConfig>
   );
 }

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -7,7 +7,11 @@ export function ToastContainer() {
   const removeToast = useToastStore((state) => state.removeToast);
 
   return (
-    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2">
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed bottom-4 right-4 z-50 flex flex-col gap-2"
+    >
       <AnimatePresence>
         {toasts.map((toast) => (
           <motion.div
@@ -17,7 +21,7 @@ export function ToastContainer() {
             exit={{ opacity: 0, y: 20, scale: 0.95 }}
             transition={{ duration: 0.2 }}
             className={clsx(
-              'px-4 py-3 rounded-lg shadow-lg text-sm font-medium cursor-pointer max-w-sm',
+              'flex items-center gap-2 px-4 py-3 rounded-lg shadow-lg text-sm font-medium cursor-pointer max-w-sm',
               {
                 'bg-green-600 text-white': toast.type === 'success',
                 'bg-red-600 text-white': toast.type === 'error',
@@ -26,7 +30,18 @@ export function ToastContainer() {
             )}
             onClick={() => removeToast(toast.id)}
           >
-            {toast.message}
+            <span className="flex-1">{toast.message}</span>
+            <button
+              type="button"
+              aria-label="Close notification"
+              className="flex-shrink-0 rounded p-0.5 focus:outline-none focus:ring-2 focus:ring-white/70"
+              onClick={(e) => {
+                e.stopPropagation();
+                removeToast(toast.id);
+              }}
+            >
+              ✕
+            </button>
           </motion.div>
         ))}
       </AnimatePresence>

--- a/src/components/ui/__tests__/Toast.test.tsx
+++ b/src/components/ui/__tests__/Toast.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ToastContainer } from '../Toast';
+import { useToastStore } from '@/hooks/useToast';
+
+function resetStore() {
+  useToastStore.setState({ toasts: [] });
+}
+
+describe('ToastContainer', () => {
+  beforeEach(() => {
+    resetStore();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    resetStore();
+  });
+
+  it('renders a toast message inside a region with role="status"', () => {
+    useToastStore.setState({
+      toasts: [{ id: 'test-1', message: 'Hello world', type: 'info' }],
+    });
+    render(<ToastContainer />);
+
+    const region = screen.getByRole('status');
+    expect(region).toBeDefined();
+    expect(region.textContent).toContain('Hello world');
+  });
+
+  it('close button has an accessible name and clicking it removes the toast', () => {
+    useToastStore.setState({
+      toasts: [{ id: 'test-2', message: 'Dismiss me', type: 'success' }],
+    });
+    render(<ToastContainer />);
+
+    const closeBtn = screen.getByRole('button', {
+      name: /close notification/i,
+    });
+    expect(closeBtn).toBeDefined();
+
+    fireEvent.click(closeBtn);
+
+    expect(useToastStore.getState().toasts).toHaveLength(0);
+  });
+
+  it('error-type toast gets the red styling class', () => {
+    useToastStore.setState({
+      toasts: [
+        { id: 'test-3', message: 'Something went wrong', type: 'error' },
+      ],
+    });
+    render(<ToastContainer />);
+
+    const msgEl = screen.getByText('Something went wrong');
+    const toastDiv = msgEl.closest('div');
+    expect(toastDiv?.className).toContain('bg-red-600');
+  });
+});


### PR DESCRIPTION
## Summary

2026-06-13 レビューの a11y クイックウィン 2 件です（旧レビュー M-17 + 新規指摘）。

- **Toast の SR 通知 (M-17)**: トーストはエクスポート失敗の唯一の通知経路なのに `aria-live` がなく、スクリーンリーダーには何も伝わっていませんでした。常時マウントされているコンテナに `role="status"` / `aria-live="polite"` を付与（live region は内容挿入前に存在している必要があるため、この構造が正解です）。あわせて「div の onClick でしか閉じられない」問題に対し、キーボードフォーカス可能な ✕ ボタンを追加（`aria-label` 付き、色付き背景でも見えるフォーカスリング、`stopPropagation` で二重発火防止）
- **prefers-reduced-motion**: `App` を `<MotionConfig reducedMotion="user">` で包み、全 framer-motion アニメーション（6 コンポーネント）が OS の motion 設定に追従するように。DOM 構造は不変です

## Test plan

- [x] リポジトリ初のコンポーネントテストとして `Toast.test.tsx` を追加（role="status" リージョン / close ボタンのアクセシブルネームと削除動作 / error 色の clsx マッピング）。fake timers で `addToast` の 4 秒タイマーのリークを防止
- [x] vitest 99件 / tsc / eslint / prettier すべて pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)