### PR TITLE
chore: bump CI to Node 22 (Node 20 is EOL)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ src/
 
 ## 📋 Requirements
 
-- Node.js 20+
+- Node.js 22+
 - Modern browser with Canvas API support
 - JavaScript enabled (client-side processing)
 


### PR DESCRIPTION
## Summary

Node 20 は 2026 年 4 月で EOL を迎えたため、CI の `node-version` を 22 (Active LTS) に更新し、README の動作要件も追従させました。ローカル開発環境は Node 24 で動作確認済みです。

## Test plan

- [x] この PR の CI 自体が Node 22 で全ステップ（lint / format / tsc / test / build）を通ることで検証されます

🤖 Generated with [Claude Code](https://claude.com/claude-code)