### PR TITLE
fix: make the Remove button always visible (was hover-only)

### DIFF
--- a/src/components/workspace/ImageWorkspace.tsx
+++ b/src/components/workspace/ImageWorkspace.tsx
@@ -1,5 +1,5 @@
-import { useState, useRef, useCallback } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { useRef, useCallback } from 'react';
+import { motion } from 'framer-motion';
 import clsx from 'clsx';
 
 import { useImageUpload } from '@/hooks/useImageUpload';
@@ -7,8 +7,6 @@ import { useCanvasRenderer } from '@/hooks/useCanvasRenderer';
 import { usePanZoom } from '@/hooks/usePanZoom';
 
 export function ImageWorkspace() {
-  const [showControls, setShowControls] = useState(false);
-
   // Refs for pan/zoom — must be created unconditionally (Rules of Hooks).
   // viewportRef → the canvas-area div (the overflow-hidden scroll viewport).
   // contentRef  → the wrapper div around the canvas that receives the transform.
@@ -38,7 +36,6 @@ export function ImageWorkspace() {
 
   const handleClearImage = () => {
     clearImage();
-    setShowControls(false);
   };
 
   const rootProps = getRootProps();
@@ -124,11 +121,7 @@ export function ImageWorkspace() {
   }
 
   return (
-    <div
-      className="relative w-full h-full"
-      onMouseEnter={() => setShowControls(true)}
-      onMouseLeave={() => setShowControls(false)}
-    >
+    <div className="relative w-full h-full">
       {/* Main Canvas Area — the pan/zoom viewport */}
       <div
         {...rootProps}
@@ -243,25 +236,17 @@ export function ImageWorkspace() {
         )}
       </div>
 
-      {/* Floating Controls */}
-      <AnimatePresence>
-        {showControls && (
-          <motion.div
-            className="absolute top-4 right-4 flex space-x-2"
-            initial={{ opacity: 0, y: -10 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: -10 }}
-            transition={{ duration: 0.2 }}
-          >
-            <button
-              onClick={handleClearImage}
-              className="px-3 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors text-sm font-medium shadow-lg"
-            >
-              Remove
-            </button>
-          </motion.div>
-        )}
-      </AnimatePresence>
+      {/* Floating Controls — always visible: a hover-gated button is
+          unreachable for keyboard and touch users (WCAG 2.1; prior review
+          M-15), and the info bar below is permanent anyway. */}
+      <div className="absolute top-4 right-4 flex space-x-2">
+        <button
+          onClick={handleClearImage}
+          className="px-3 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors text-sm font-medium shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80"
+        >
+          Remove
+        </button>
+      </div>
 
       {/* Image Info Bar */}
       <div className="absolute bottom-4 left-4 bg-black/75 dark:bg-gray-900/90 text-white px-4 py-2 rounded-lg text-sm">


### PR DESCRIPTION
## Summary

旧レビュー M-15 の修正です。Remove ボタンが `onMouseEnter` でしか出現せず、**キーボード・タッチユーザーは画像を削除できませんでした**（WCAG 2.1）。クローズした #183 のコンテキストメニュー案に代わる、最小・正攻法の解です。

- ボタンを常時表示に（常時表示の Image Info Bar とデザイン的にも一貫）
- キーボード操作向けに `focus-visible` リングを明示
- `showControls` state、マウスハンドラ、未使用になった `AnimatePresence` / `useState` import を削除（差分は実質マイナス：+14 / −29）

> **Note**: #182（pan/zoom）にスタックしています。#182 マージ後に base が自動で main に切り替わります。

## Test plan

実ブラウザ（Playwright + Chromium）で検証済み：
- [x] マウス非ホバー状態でボタンが見える
- [x] Tab でフォーカス到達 → Enter で削除され空状態に戻る（フォーカスリング表示をスクリーンショットで確認）
- [x] hover イベントなしのクリック（タッチ相当）でも削除できる
- [x] vitest 123 件 / tsc / eslint / prettier すべて pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)