### PR TITLE
fix: use render DPR for frosted panel exports

### DIFF
--- a/src/services/__tests__/canvasRenderer.test.ts
+++ b/src/services/__tests__/canvasRenderer.test.ts
@@ -188,6 +188,89 @@ describe('CanvasRenderer.calculateOptimalSize', () => {
   });
 });
 
+describe('CanvasRenderer frosted panel sampling', () => {
+  it('uses the render DPR instead of the device DPR for export sampling', () => {
+    const originalDevicePixelRatio = window.devicePixelRatio;
+    Object.defineProperty(window, 'devicePixelRatio', {
+      value: 2,
+      configurable: true,
+    });
+
+    const offscreenDrawImage = vi.fn();
+    const offscreenScale = vi.fn();
+    const offscreenContext = {
+      scale: offscreenScale,
+      drawImage: offscreenDrawImage,
+      imageSmoothingEnabled: false,
+      imageSmoothingQuality: 'low',
+      filter: 'none',
+    } as unknown as CanvasRenderingContext2D;
+    const offscreenCanvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn(() => offscreenContext),
+    } as unknown as HTMLCanvasElement;
+    const sourceCanvas = { width: 400, height: 300 } as HTMLCanvasElement;
+    const context = {
+      canvas: sourceCanvas,
+      save: vi.fn(),
+      beginPath: vi.fn(),
+      roundRect: vi.fn(),
+      clip: vi.fn(),
+      drawImage: vi.fn(),
+      fillRect: vi.fn(),
+      stroke: vi.fn(),
+      restore: vi.fn(),
+      fillStyle: '',
+    } as unknown as CanvasRenderingContext2D;
+    const createElementSpy = vi
+      .spyOn(document, 'createElement')
+      .mockReturnValue(offscreenCanvas);
+
+    const drawFrostedPanel = (
+      CanvasRenderer as unknown as {
+        drawFrostedPanel: (
+          ctx: CanvasRenderingContext2D,
+          x: number,
+          y: number,
+          width: number,
+          height: number,
+          radius: number,
+          scaleFactor: number,
+          backgroundColor: string,
+          devicePixelRatio: number
+        ) => void;
+      }
+    ).drawFrostedPanel.bind(CanvasRenderer);
+
+    try {
+      // Exports explicitly render at DPR 1, even on a DPR 2 display.
+      drawFrostedPanel(context, 10, 20, 30, 40, 5, 1, '#fff', 1);
+
+      expect(offscreenCanvas.width).toBe(30);
+      expect(offscreenCanvas.height).toBe(40);
+      expect(offscreenScale).toHaveBeenCalledWith(1, 1);
+      expect(offscreenDrawImage).toHaveBeenCalledWith(
+        sourceCanvas,
+        10,
+        20,
+        30,
+        40,
+        0,
+        0,
+        30,
+        40
+      );
+    } finally {
+      createElementSpy.mockRestore();
+      Object.defineProperty(window, 'devicePixelRatio', {
+        value: originalDevicePixelRatio,
+        configurable: true,
+      });
+    }
+  });
+});
+
 // loadFontCached is exported for testing. jsdom does not ship document.fonts,
 // so each test defines it as a stub. vi.resetModules() + dynamic import gives
 // each test a fresh module-level fontLoadCache so cache tests are independent.

--- a/src/services/canvasRenderer.ts
+++ b/src/services/canvasRenderer.ts
@@ -482,6 +482,7 @@ export class CanvasRenderer {
       this.drawTemplate(ctx, dynamicTemplate, exifData, scaleFactor, {
         imageIsPortrait: isPortraitImage,
         overlayPosition: effectiveSettings.overlayPosition,
+        devicePixelRatio,
       });
     }
   }
@@ -1384,7 +1385,8 @@ export class CanvasRenderer {
     ctx: CanvasRenderingContext2D,
     template: Template,
     exifData: NormalizedExifData,
-    scaleFactor: number
+    scaleFactor: number,
+    devicePixelRatio: number
   ): void {
     const { style, position } = template;
     const panelX = position.x;
@@ -1407,7 +1409,8 @@ export class CanvasRenderer {
       panelH,
       layout.borderRadius,
       scaleFactor,
-      style.backgroundColor
+      style.backgroundColor,
+      devicePixelRatio
     );
 
     const innerLeft = panelX + layout.padding;
@@ -1545,10 +1548,10 @@ export class CanvasRenderer {
     h: number,
     radius: number,
     scaleFactor: number,
-    backgroundColor: string
+    backgroundColor: string,
+    devicePixelRatio: number
   ): void {
-    const dpr =
-      typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
+    const dpr = devicePixelRatio;
     const canCreateOffscreen =
       typeof document !== 'undefined' && w > 0 && h > 0;
 
@@ -1877,7 +1880,8 @@ export class CanvasRenderer {
     ctx: CanvasRenderingContext2D,
     template: Template,
     exifData: NormalizedExifData,
-    scaleFactor: number
+    scaleFactor: number,
+    devicePixelRatio: number
   ): void {
     const { style, position } = template;
     const panelX = position.x;
@@ -1895,7 +1899,8 @@ export class CanvasRenderer {
       panelH,
       layout.borderRadius,
       scaleFactor,
-      style.backgroundColor
+      style.backgroundColor,
+      devicePixelRatio
     );
 
     const headerHeight =
@@ -2261,7 +2266,8 @@ export class CanvasRenderer {
     ctx: CanvasRenderingContext2D,
     template: Template,
     exifData: NormalizedExifData,
-    scaleFactor: number
+    scaleFactor: number,
+    devicePixelRatio: number
   ): void {
     const { style, position } = template;
     const panelX = position.x;
@@ -2279,7 +2285,8 @@ export class CanvasRenderer {
       panelH,
       layout.borderRadius,
       scaleFactor,
-      style.backgroundColor
+      style.backgroundColor,
+      devicePixelRatio
     );
 
     const innerLeft = panelX + layout.padding;
@@ -3176,6 +3183,7 @@ export class CanvasRenderer {
     options?: {
       imageIsPortrait?: boolean;
       overlayPosition?: PositionPreset;
+      devicePixelRatio?: number;
     }
   ): void {
     const { style, position } = template;
@@ -3191,16 +3199,29 @@ export class CanvasRenderer {
           ctx,
           template,
           exifData,
-          scaleFactor
+          scaleFactor,
+          options?.devicePixelRatio ?? 1
         );
       } else {
-        this.drawTechnicalTemplate(ctx, template, exifData, scaleFactor);
+        this.drawTechnicalTemplate(
+          ctx,
+          template,
+          exifData,
+          scaleFactor,
+          options?.devicePixelRatio ?? 1
+        );
       }
       return;
     }
 
     if (template.customDraw === 'compact') {
-      this.drawCompactTemplate(ctx, template, exifData, scaleFactor);
+      this.drawCompactTemplate(
+        ctx,
+        template,
+        exifData,
+        scaleFactor,
+        options?.devicePixelRatio ?? 1
+      );
       return;
     }
 


### PR DESCRIPTION
What:
Use the renderer's effective DPR when exporting frosted panels so export output matches the actual render context.

Why:
The previous code re-read the window DPR during export, which could diverge from the value used by rendering.

Impact:
Exports are more consistent across device and export DPR combinations.

Checks:
- TypeScript
- lint
- tests
- build

Notes:
This is the preferred first merge in the renderer/export sequence because later text-wrapping changes touch the same rendering surface.