### PR TITLE
fix: reject oversized images before decoding

### DIFF
--- a/src/hooks/useImageUpload.ts
+++ b/src/hooks/useImageUpload.ts
@@ -67,7 +67,9 @@ export function useImageUpload() {
       } catch (error: unknown) {
         if (signal.aborted) return;
         console.error('Error loading image:', error);
-        toast.error('Failed to load image.');
+        toast.error(
+          error instanceof Error ? error.message : 'Failed to load image.'
+        );
       }
     },
     [setImage, setExifData, setNormalizedData, toast]

--- a/src/services/__tests__/imageProcessor.test.ts
+++ b/src/services/__tests__/imageProcessor.test.ts
@@ -55,3 +55,76 @@ describe('ImageProcessor.validateImageFile', () => {
     expect(result.valid).toBe(true);
   });
 });
+
+describe('ImageProcessor.validateImageDimensions', () => {
+  function fileFromBytes(bytes: Uint8Array<ArrayBuffer>, type: string): File {
+    return new File([bytes], 'image', { type });
+  }
+
+  function pngFile(width: number, height: number): File {
+    const bytes = new Uint8Array(24);
+    bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const view = new DataView(bytes.buffer);
+    view.setUint32(16, width);
+    view.setUint32(20, height);
+    return fileFromBytes(bytes, 'image/png');
+  }
+
+  function jpegFile(width: number, height: number): File {
+    const bytes = new Uint8Array(21);
+    const view = new DataView(bytes.buffer);
+    bytes.set([0xff, 0xd8, 0xff, 0xc0]);
+    view.setUint16(4, 17);
+    view.setUint8(6, 8);
+    view.setUint16(7, height);
+    view.setUint16(9, width);
+    bytes.set([0xff, 0xd9], 19);
+    return fileFromBytes(bytes, 'image/jpeg');
+  }
+
+  function heicFile(width: number, height: number): File {
+    const bytes = new Uint8Array(24);
+    const view = new DataView(bytes.buffer);
+    view.setUint32(0, 24);
+    bytes.set([0x69, 0x73, 0x70, 0x65], 4);
+    view.setUint32(12, width);
+    view.setUint32(16, height);
+    return fileFromBytes(bytes, 'image/heic');
+  }
+
+  it.each([
+    ['PNG', pngFile(8000, 8000)],
+    ['JPEG', jpegFile(8000, 8000)],
+    ['HEIC', heicFile(8000, 8000)],
+  ])('accepts a %s at the 64 megapixel boundary', async (_name, file) => {
+    await expect(ImageProcessor.validateImageDimensions(file)).resolves.toEqual(
+      { valid: true }
+    );
+  });
+
+  it('rejects an image above the total pixel limit', async () => {
+    const result = await ImageProcessor.validateImageDimensions(
+      pngFile(8001, 8000)
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('64 megapixels');
+  });
+
+  it('rejects an image above the per-side dimension limit', async () => {
+    const result = await ImageProcessor.validateImageDimensions(
+      jpegFile(16_385, 1)
+    );
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('16384px per side');
+  });
+
+  it('rejects malformed image headers before decoding', async () => {
+    const result = await ImageProcessor.validateImageDimensions(
+      fileFromBytes(new Uint8Array([1, 2, 3]), 'image/png')
+    );
+    expect(result).toEqual({
+      valid: false,
+      error: 'Unable to read image dimensions.',
+    });
+  });
+});

--- a/src/services/imageProcessor.ts
+++ b/src/services/imageProcessor.ts
@@ -1,7 +1,110 @@
 import type { ImageFile } from '@/types/image';
 
+const MAX_IMAGE_PIXELS = 64_000_000;
+const MAX_IMAGE_DIMENSION = 16_384;
+
+interface ImageDimensions {
+  width: number;
+  height: number;
+}
+
+function readPngDimensions(view: DataView): ImageDimensions | null {
+  if (view.byteLength < 24) return null;
+  const signature = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+  if (signature.some((byte, index) => view.getUint8(index) !== byte)) {
+    return null;
+  }
+  return { width: view.getUint32(16), height: view.getUint32(20) };
+}
+
+function isJpegStartOfFrame(marker: number): boolean {
+  return (
+    (marker >= 0xc0 && marker <= 0xc3) ||
+    (marker >= 0xc5 && marker <= 0xc7) ||
+    (marker >= 0xc9 && marker <= 0xcb) ||
+    (marker >= 0xcd && marker <= 0xcf)
+  );
+}
+
+function readJpegDimensions(view: DataView): ImageDimensions | null {
+  if (
+    view.byteLength < 4 ||
+    view.getUint8(0) !== 0xff ||
+    view.getUint8(1) !== 0xd8
+  ) {
+    return null;
+  }
+
+  let offset = 2;
+  while (offset + 3 < view.byteLength) {
+    while (offset < view.byteLength && view.getUint8(offset) !== 0xff) {
+      offset += 1;
+    }
+    while (offset < view.byteLength && view.getUint8(offset) === 0xff) {
+      offset += 1;
+    }
+    if (offset >= view.byteLength) return null;
+
+    const marker = view.getUint8(offset);
+    offset += 1;
+    if (marker === 0xd8 || marker === 0xd9 || marker === 0x01) continue;
+    if (offset + 1 >= view.byteLength) return null;
+
+    const segmentLength = view.getUint16(offset);
+    if (segmentLength < 2 || offset + segmentLength > view.byteLength) {
+      return null;
+    }
+    if (isJpegStartOfFrame(marker)) {
+      if (segmentLength < 7) return null;
+      return {
+        height: view.getUint16(offset + 3),
+        width: view.getUint16(offset + 5),
+      };
+    }
+    if (marker === 0xda) return null;
+    offset += segmentLength;
+  }
+  return null;
+}
+
+function readHeifDimensions(view: DataView): ImageDimensions | null {
+  // HEIF stores the primary image dimensions in an Image Spatial Extents
+  // (`ispe`) full box: type, version/flags, width, height. It may be nested
+  // several boxes deep, so scan the validated box signature rather than
+  // assuming a fixed container path.
+  let maxWidth = 0;
+  let maxHeight = 0;
+  for (
+    let typeOffset = 4;
+    typeOffset + 16 <= view.byteLength;
+    typeOffset += 1
+  ) {
+    if (
+      view.getUint8(typeOffset) !== 0x69 ||
+      view.getUint8(typeOffset + 1) !== 0x73 ||
+      view.getUint8(typeOffset + 2) !== 0x70 ||
+      view.getUint8(typeOffset + 3) !== 0x65
+    ) {
+      continue;
+    }
+    const boxStart = typeOffset - 4;
+    const boxSize = view.getUint32(boxStart);
+    if (boxSize < 20 || boxStart + boxSize > view.byteLength) continue;
+    maxWidth = Math.max(maxWidth, view.getUint32(typeOffset + 8));
+    maxHeight = Math.max(maxHeight, view.getUint32(typeOffset + 12));
+  }
+  return maxWidth && maxHeight ? { width: maxWidth, height: maxHeight } : null;
+}
+
 export class ImageProcessor {
   static async loadImageFile(file: File): Promise<ImageFile> {
+    const dimensionValidation = await this.validateImageDimensions(file);
+    if (!dimensionValidation.valid) {
+      throw new Error(
+        dimensionValidation.error ?? 'Unable to read image dimensions.'
+      );
+    }
+
     return new Promise((resolve, reject) => {
       const img = new Image();
       const url = URL.createObjectURL(file);
@@ -52,6 +155,38 @@ export class ImageProcessor {
       };
     }
 
+    return { valid: true };
+  }
+
+  static async validateImageDimensions(
+    file: File
+  ): Promise<{ valid: boolean; error?: string }> {
+    const view = new DataView(await file.arrayBuffer());
+    let dimensions: ImageDimensions | null;
+    if (file.type === 'image/png') {
+      dimensions = readPngDimensions(view);
+    } else if (file.type === 'image/jpeg') {
+      dimensions = readJpegDimensions(view);
+    } else if (file.type === 'image/heic' || file.type === 'image/heif') {
+      dimensions = readHeifDimensions(view);
+    } else {
+      return { valid: false, error: 'Unsupported file type.' };
+    }
+
+    if (!dimensions || dimensions.width <= 0 || dimensions.height <= 0) {
+      return { valid: false, error: 'Unable to read image dimensions.' };
+    }
+    if (
+      dimensions.width > MAX_IMAGE_DIMENSION ||
+      dimensions.height > MAX_IMAGE_DIMENSION ||
+      dimensions.width * dimensions.height > MAX_IMAGE_PIXELS
+    ) {
+      return {
+        valid: false,
+        error:
+          'Image dimensions are too large. Maximum is 64 megapixels and 16384px per side.',
+      };
+    }
     return { valid: true };
   }
 


### PR DESCRIPTION
What:
Validate JPEG/PNG/HEIC dimensions from headers before full decode and reject images above the safety limits.

Why:
Large or malformed images could consume excessive memory or stall decode work.

Impact:
Uploads now fail fast with a clearer error before expensive processing starts.

Checks:
- TypeScript
- lint
- tests
- build

Notes:
This should land before the HEIC and EXIF pipeline changes because they share the same upload path.