### PR TITLE
fix: clarify native HEIC browser support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ CI runs: lint → format:check → tsc --noEmit → test → build.
   - `exifExtractor.ts` — Reads EXIF via exifr and normalizes to display strings (ja-JP locale for dates). Routes Sony bodies through `cameraNameFormatter`.
   - `cameraNameFormatter.ts` — Rewrites Sony ILCE/ILCA/DSC model codes into the marketing α-series names (e.g. `ILCE-7M4` → `α7 IV`).
   - `canvasRenderer.ts` — Canvas drawing with dynamic height calculation, text wrapping, responsive font scaling, 4K support. Dispatches per-template rendering via the template's `customDraw` (`caption`, `technical`, `compact`, `imprint`, `gallery-placard`); the film template auto-rotates for portrait images.
-  - `imageProcessor.ts` — File validation (JPEG/PNG/HEIC, max 20MB), Blob URL lifecycle.
+  - `imageProcessor.ts` — File validation (JPEG/PNG and natively supported HEIC, max 20MB), Blob URL lifecycle.
 - **`src/stores/`** — Zustand stores. Mostly independent; the one cross-store call is `imageStore` clearing `exifStore` when the image is replaced or removed (prevents stale EXIF leaking across images).
   - `imageStore` / `templateStore` — selected image and template preset.
   - `exifStore` — raw + normalized EXIF, plus per-image `lensOverrides` / `locationOverrides` exposed via `getEffectiveNormalizedData`.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ npm run build
 
 ## 📷 How It Works
 
-1. **Upload**: Drag & drop your photos (JPEG, PNG, HEIC)
+1. **Upload**: Drag & drop your photos (JPEG, PNG, and HEIC where the browser supports native decoding)
 2. **Extract**: Automatic EXIF metadata extraction
 3. **Style**: Choose from professional templates
 4. **Export**: Download high-quality images with beautiful overlays

--- a/src/components/workspace/ImageWorkspace.tsx
+++ b/src/components/workspace/ImageWorkspace.tsx
@@ -121,7 +121,7 @@ export function ImageWorkspace() {
             </p>
 
             <p className="font-mono text-xs uppercase tracking-wider text-zinc-600">
-              JPEG · PNG · HEIC — up to 20 MB
+              JPEG · PNG · HEIC (supported browsers) — up to 20 MB
             </p>
           </div>
 

--- a/src/hooks/useImageUpload.ts
+++ b/src/hooks/useImageUpload.ts
@@ -67,7 +67,9 @@ export function useImageUpload() {
       } catch (error: unknown) {
         if (signal.aborted) return;
         console.error('Error loading image:', error);
-        toast.error('Failed to load image.');
+        toast.error(
+          error instanceof Error ? error.message : 'Failed to load image.'
+        );
       }
     },
     [setImage, setExifData, setNormalizedData, toast]

--- a/src/services/__tests__/imageProcessor.test.ts
+++ b/src/services/__tests__/imageProcessor.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { ImageProcessor } from '../imageProcessor';
 
 describe('ImageProcessor.validateImageFile', () => {
@@ -30,6 +30,37 @@ describe('ImageProcessor.validateImageFile', () => {
     const file = createMockFile('image/heif', 1024);
     const result = ImageProcessor.validateImageFile(file);
     expect(result.valid).toBe(true);
+  });
+
+  it('explains the native browser requirement when HEIC decoding fails', async () => {
+    const file = createMockFile('image/heic', 1024);
+    const revokeObjectURL = vi.fn();
+
+    class FailingImage {
+      width = 0;
+      height = 0;
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+
+      set src(_value: string) {
+        this.onerror?.();
+      }
+    }
+
+    vi.stubGlobal('Image', FailingImage);
+    vi.stubGlobal('URL', {
+      createObjectURL: vi.fn(() => 'blob:heic'),
+      revokeObjectURL,
+    });
+
+    try {
+      await expect(ImageProcessor.loadImageFile(file)).rejects.toThrow(
+        'HEIC decoding is not supported by this browser'
+      );
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:heic');
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it('rejects unsupported file types', () => {

--- a/src/services/imageProcessor.ts
+++ b/src/services/imageProcessor.ts
@@ -22,7 +22,14 @@ export class ImageProcessor {
 
       img.onerror = () => {
         URL.revokeObjectURL(url);
-        reject(new Error('Failed to load image'));
+        const isHeic = file.type === 'image/heic' || file.type === 'image/heif';
+        reject(
+          new Error(
+            isHeic
+              ? 'HEIC decoding is not supported by this browser. Convert the image to JPEG or PNG and try again.'
+              : 'Failed to load image.'
+          )
+        );
       };
 
       img.src = url;


### PR DESCRIPTION
What:
Keep native browser HEIC support intact, but surface a clearer error when the browser cannot decode HEIC.

Why:
The UI previously implied support in a way that could mislead users on unsupported browsers.

Impact:
Users get a more explicit failure mode and clearer browser guidance.

Checks:
- TypeScript
- lint
- tests
- build

Notes:
This depends on the image-size guard path conceptually, so it is best merged after the oversized-image check.