### PR TITLE
fix: cancel EXIF extraction when removing images

### DIFF
--- a/src/hooks/__tests__/useImageUpload.test.ts
+++ b/src/hooks/__tests__/useImageUpload.test.ts
@@ -1,0 +1,106 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ExifData, NormalizedExifData } from '@/types/exif';
+import type { ImageFile } from '@/types/image';
+
+const mocks = vi.hoisted(() => ({
+  onDrop: null as ((files: File[]) => Promise<void>) | null,
+  extractExifData: vi.fn<(file: File) => Promise<ExifData>>(),
+  normalizeExifData: vi.fn<(data: ExifData) => NormalizedExifData>(),
+}));
+
+vi.mock('react-dropzone', () => ({
+  useDropzone: (options: { onDrop: (files: File[]) => Promise<void> }) => {
+    mocks.onDrop = options.onDrop;
+    return {
+      getRootProps: () => ({}),
+      getInputProps: () => ({}),
+      isDragActive: false,
+      isDragReject: false,
+    };
+  },
+}));
+
+vi.mock('@/services/exifExtractor', () => ({
+  extractExifData: mocks.extractExifData,
+  normalizeExifData: mocks.normalizeExifData,
+}));
+
+import { useImageUpload } from '../useImageUpload';
+import { ImageProcessor } from '@/services/imageProcessor';
+import { useExifStore } from '@/stores/exifStore';
+import { useImageStore } from '@/stores/imageStore';
+
+const normalizedData: NormalizedExifData = {
+  camera: 'Sony α7 IV',
+  cameraMake: 'Sony',
+  cameraModel: 'α7 IV',
+  lens: null,
+  focalLength: null,
+  aperture: null,
+  shutterSpeed: null,
+  iso: null,
+  dateTime: null,
+  location: null,
+};
+
+const imageFile: ImageFile = {
+  id: 'image-1',
+  name: 'image.jpg',
+  url: 'blob:image-1',
+  size: 1024,
+  type: 'image/jpeg',
+  width: 1920,
+  height: 1080,
+};
+
+describe('useImageUpload', () => {
+  beforeEach(() => {
+    mocks.onDrop = null;
+    mocks.extractExifData.mockReset();
+    mocks.normalizeExifData.mockReset();
+    useImageStore.setState({ currentImage: null });
+    useExifStore.setState({
+      exifData: {},
+      normalizedData: {},
+      lensOverrides: {},
+      locationOverrides: {},
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not restore EXIF data after the image is removed', async () => {
+    let resolveExif!: (data: ExifData) => void;
+    const pendingExif = new Promise<ExifData>((resolve) => {
+      resolveExif = resolve;
+    });
+    mocks.extractExifData.mockReturnValue(pendingExif);
+    mocks.normalizeExifData.mockReturnValue(normalizedData);
+    vi.spyOn(ImageProcessor, 'loadImageFile').mockResolvedValue(imageFile);
+
+    const { result } = renderHook(() => useImageUpload());
+    const file = new File(['jpeg'], 'image.jpg', { type: 'image/jpeg' });
+
+    await act(async () => {
+      await mocks.onDrop?.([file]);
+    });
+    expect(useImageStore.getState().currentImage?.id).toBe(imageFile.id);
+
+    act(() => {
+      result.current.clearImage();
+    });
+    expect(useImageStore.getState().currentImage).toBeNull();
+
+    await act(async () => {
+      resolveExif({ camera: { make: 'Sony' } });
+      await pendingExif;
+    });
+
+    expect(useExifStore.getState().exifData).toEqual({});
+    expect(useExifStore.getState().normalizedData).toEqual({});
+    expect(mocks.normalizeExifData).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useImageUpload.ts
+++ b/src/hooks/useImageUpload.ts
@@ -22,6 +22,12 @@ export function useImageUpload() {
     };
   }, []);
 
+  const clearCurrentImage = useCallback(() => {
+    exifAbortRef.current?.abort();
+    exifAbortRef.current = null;
+    clearImage();
+  }, [clearImage]);
+
   const onDrop = useCallback(
     async (acceptedFiles: File[]) => {
       const file = acceptedFiles[0];
@@ -55,6 +61,9 @@ export function useImageUpload() {
         extractExifData(file)
           .then((exifData) => {
             if (signal.aborted) return;
+            if (useImageStore.getState().currentImage?.id !== imageFile.id) {
+              return;
+            }
             setExifData(imageFile.id, exifData);
             const normalized = normalizeExifData(exifData);
             setNormalizedData(imageFile.id, normalized);
@@ -87,7 +96,7 @@ export function useImageUpload() {
 
   return {
     currentImage,
-    clearImage,
+    clearImage: clearCurrentImage,
     ...dropzone,
   };
 }


### PR DESCRIPTION
What:
Abort in-flight EXIF extraction and avoid writing results back after the image has been removed.

Why:
A pending extraction could race with removal and update stale state.

Impact:
Image removal is now safe even if metadata parsing is still in progress.

Checks:
- TypeScript
- lint
- tests
- build

Notes:
This is another upload-path change that should be merged after the resource-limit and HEIC fixes.