### PR TITLE
fix: size previews to the workspace container

### DIFF
--- a/src/hooks/__tests__/useResponsiveCanvas.test.ts
+++ b/src/hooks/__tests__/useResponsiveCanvas.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { getDisplayBounds } from '../useResponsiveCanvas';
+
+const originalInnerWidth = window.innerWidth;
+
+afterEach(() => {
+  Object.defineProperty(window, 'innerWidth', {
+    value: originalInnerWidth,
+    configurable: true,
+  });
+});
+
+describe('getDisplayBounds', () => {
+  it('caps the desktop canvas to the actual workspace width', () => {
+    Object.defineProperty(window, 'innerWidth', {
+      value: 1024,
+      configurable: true,
+    });
+
+    expect(getDisplayBounds(612)).toEqual({
+      maxDisplayWidth: 612,
+      maxDisplayHeight: 600,
+    });
+  });
+
+  it('keeps the normal desktop cap when the workspace is wider', () => {
+    Object.defineProperty(window, 'innerWidth', {
+      value: 1440,
+      configurable: true,
+    });
+
+    expect(getDisplayBounds(900).maxDisplayWidth).toBe(700);
+  });
+});

--- a/src/hooks/useResponsiveCanvas.ts
+++ b/src/hooks/useResponsiveCanvas.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect, type RefObject } from 'react';
 import type { ProcessedImage } from '@/types/image';
 
-export function getDisplayBounds(): {
+export function getDisplayBounds(containerWidth?: number): {
   maxDisplayWidth: number;
   maxDisplayHeight: number;
 } {
@@ -10,11 +10,15 @@ export function getDisplayBounds(): {
   const isTablet = windowWidth < 1024;
   const horizontalMargin = 40;
 
-  const maxDisplayWidth = isMobile
+  const responsiveMaxWidth = isMobile
     ? Math.min(300, windowWidth - horizontalMargin)
     : isTablet
       ? Math.min(500, windowWidth - horizontalMargin)
       : Math.min(700, windowWidth - horizontalMargin);
+  const maxDisplayWidth = Math.max(
+    1,
+    Math.min(responsiveMaxWidth, containerWidth ?? responsiveMaxWidth)
+  );
 
   const maxDisplayHeight = isMobile ? 400 : isTablet ? 500 : 600;
 
@@ -40,7 +44,10 @@ export function useResponsiveCanvas(
     const logicalHeight = canvas.height / devicePixelRatio;
     const canvasAspectRatio = logicalWidth / logicalHeight;
 
-    const { maxDisplayWidth, maxDisplayHeight } = getDisplayBounds();
+    const viewport = canvas.parentElement?.parentElement;
+    const { maxDisplayWidth, maxDisplayHeight } = getDisplayBounds(
+      viewport?.clientWidth
+    );
 
     let displayWidth, displayHeight;
 
@@ -64,6 +71,7 @@ export function useResponsiveCanvas(
 
     canvas.style.width = `${displayWidth}px`;
     canvas.style.height = `${displayHeight}px`;
+    canvas.style.maxWidth = '100%';
 
     const topMargin = 20;
     const bottomMargin = 20;
@@ -78,8 +86,18 @@ export function useResponsiveCanvas(
     };
 
     window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, [updateCanvasDisplaySize]);
+    const viewport = canvasRef.current?.parentElement?.parentElement;
+    const resizeObserver =
+      viewport && typeof ResizeObserver !== 'undefined'
+        ? new ResizeObserver(handleResize)
+        : null;
+    if (viewport) resizeObserver?.observe(viewport);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+      resizeObserver?.disconnect();
+    };
+  }, [canvasRef, updateCanvasDisplaySize]);
 
   return {
     containerHeight,


### PR DESCRIPTION
What:
Compute preview display bounds from the actual workspace container width and keep the preview responsive with ResizeObserver.

Why:
The old sizing path assumed a wider layout than some containers actually provide.

Impact:
Previews fit the available space more reliably, especially in narrower layouts.

Checks:
- TypeScript
- lint
- tests
- build

Notes:
This is largely independent from the upload pipeline changes.