### PR TITLE
fix: wrap unbroken overlay text safely

### DIFF
--- a/src/services/__tests__/canvasRenderer.test.ts
+++ b/src/services/__tests__/canvasRenderer.test.ts
@@ -147,6 +147,38 @@ describe('CanvasRenderer.fillTextWithBrandHighlights', () => {
   });
 });
 
+describe('CanvasRenderer.wrapText', () => {
+  const wrapText = (
+    CanvasRenderer as unknown as {
+      wrapText: (
+        ctx: CanvasRenderingContext2D,
+        text: string,
+        maxWidth: number
+      ) => string[];
+    }
+  ).wrapText.bind(CanvasRenderer);
+
+  it('wraps Japanese text without requiring spaces', () => {
+    const { ctx } = createMockCtx();
+    expect(wrapText(ctx, '東京都台東区浅草', 30)).toEqual([
+      '東京都',
+      '台東区',
+      '浅草',
+    ]);
+  });
+
+  it('wraps long ASCII tokens when no word boundary is available', () => {
+    const { ctx } = createMockCtx();
+    expect(wrapText(ctx, 'ABCDEFG', 30)).toEqual(['ABC', 'DEF', 'G']);
+  });
+
+  it('does not split a multi-code-point emoji grapheme', () => {
+    const { ctx } = createMockCtx();
+    const family = '👨‍👩‍👧‍👦';
+    expect(wrapText(ctx, `${family}東京`, 30)).toEqual([family, '東京']);
+  });
+});
+
 describe('CanvasRenderer.calculateOptimalSize', () => {
   it('returns original dimensions when within limits', () => {
     const result = CanvasRenderer.calculateOptimalSize(1920, 1080);

--- a/src/services/canvasRenderer.ts
+++ b/src/services/canvasRenderer.ts
@@ -709,20 +709,27 @@ export class CanvasRenderer {
     text: string,
     maxWidth: number
   ): string[] {
+    if (!text) return [];
+    if (maxWidth <= 0) return [text];
+
     const words = text.split(' ');
     const lines: string[] = [];
     let currentLine = '';
 
     for (const word of words) {
       const testLine = currentLine ? `${currentLine} ${word}` : word;
-      const metrics = ctx.measureText(testLine);
-
-      if (metrics.width > maxWidth && currentLine) {
-        lines.push(currentLine);
-        currentLine = word;
-      } else {
+      if (ctx.measureText(testLine).width <= maxWidth) {
         currentLine = testLine;
+        continue;
       }
+
+      if (currentLine) {
+        lines.push(currentLine);
+      }
+
+      const chunks = this.splitTokenByWidth(ctx, word, maxWidth);
+      lines.push(...chunks.slice(0, -1));
+      currentLine = chunks.at(-1) ?? '';
     }
 
     if (currentLine) {
@@ -730,6 +737,38 @@ export class CanvasRenderer {
     }
 
     return lines;
+  }
+
+  private static splitTokenByWidth(
+    ctx: CanvasRenderingContext2D,
+    token: string,
+    maxWidth: number
+  ): string[] {
+    if (!token || ctx.measureText(token).width <= maxWidth) return [token];
+
+    const graphemes =
+      typeof Intl.Segmenter === 'function'
+        ? Array.from(
+            new Intl.Segmenter(undefined, { granularity: 'grapheme' }).segment(
+              token
+            ),
+            (part) => part.segment
+          )
+        : Array.from(token);
+    const chunks: string[] = [];
+    let current = '';
+
+    for (const grapheme of graphemes) {
+      const candidate = current + grapheme;
+      if (current && ctx.measureText(candidate).width > maxWidth) {
+        chunks.push(current);
+        current = grapheme;
+      } else {
+        current = candidate;
+      }
+    }
+    if (current) chunks.push(current);
+    return chunks;
   }
 
   private static getCaptionCameraParts(exifData: NormalizedExifData): {


### PR DESCRIPTION
What:
Add grapheme-aware fallback wrapping for overlay text so long unbroken CJK and emoji strings can wrap safely.

Why:
The previous fallback path could overflow on strings without spaces.

Impact:
Overlay text stays within bounds more reliably across scripts.

Checks:
- TypeScript
- lint
- tests
- build

Notes:
This touches the same rendering area as the DPR export fix, so merge it after that renderer change.