### PR TITLE
fix: align position controls with template behavior

### DIFF
--- a/src/components/editor/PositionSelector.tsx
+++ b/src/components/editor/PositionSelector.tsx
@@ -9,7 +9,18 @@ const CORNERS: { key: PositionPreset; label: string; pos: string }[] = [
   { key: 'bottom-right', label: 'Bottom Right', pos: 'bottom-1.5 right-1.5' },
 ];
 
-export function PositionSelector() {
+const GALLERY_LAYOUTS: { key: PositionPreset; label: string }[] = [
+  { key: 'bottom-left', label: 'Bottom' },
+  { key: 'top-left', label: 'Left panel' },
+  { key: 'top-right', label: 'Right panel' },
+  { key: 'bottom-right', label: 'Split panels' },
+];
+
+export function PositionSelector({
+  variant = 'corner',
+}: {
+  variant?: 'corner' | 'gallery';
+}) {
   const currentPosition = useSettingsStore(
     (state) => state.canvasSettings.overlayPosition
   );
@@ -21,7 +32,44 @@ export function PositionSelector() {
     updateCanvasSettings({ overlayPosition: position });
   };
 
-  const activeLabel = CORNERS.find((c) => c.key === currentPosition)?.label;
+  const options = variant === 'gallery' ? GALLERY_LAYOUTS : CORNERS;
+  const activeLabel = options.find((c) => c.key === currentPosition)?.label;
+
+  if (variant === 'gallery') {
+    return (
+      <div className="space-y-3">
+        <h3 className="font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-zinc-500">
+          Placard Layout
+        </h3>
+        <div
+          className="grid grid-cols-2 gap-2"
+          role="group"
+          aria-label="Placard layout"
+        >
+          {GALLERY_LAYOUTS.map((layout) => {
+            const isSelected = currentPosition === layout.key;
+            return (
+              <button
+                key={layout.key}
+                type="button"
+                onClick={() => handlePositionChange(layout.key)}
+                aria-pressed={isSelected}
+                className={clsx(
+                  'rounded-md border px-2 py-2 text-xs font-medium transition-colors',
+                  'focus:outline-none focus:ring-2 focus:ring-accent/70',
+                  isSelected
+                    ? 'border-accent/70 bg-accent text-black'
+                    : 'border-white/10 bg-white/5 text-zinc-400 hover:border-white/25 hover:text-zinc-200'
+                )}
+              >
+                {layout.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-3">

--- a/src/components/editor/TemplateSelector.tsx
+++ b/src/components/editor/TemplateSelector.tsx
@@ -262,7 +262,29 @@ export function TemplateSelector() {
 
       {/* Position Selector */}
       <div className="border-t border-white/[0.06] pt-5">
-        <PositionSelector />
+        {selectedTemplate?.customDraw === 'caption' ? (
+          <div className="space-y-2">
+            <h3 className="font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-zinc-500">
+              Overlay Position
+            </h3>
+            <p className="text-xs text-zinc-500">
+              Caption is fixed below the photo.
+            </p>
+          </div>
+        ) : selectedTemplate?.id === 'film' ? (
+          <div className="space-y-2">
+            <h3 className="font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-zinc-500">
+              Overlay Position
+            </h3>
+            <p className="text-xs text-zinc-500">
+              Film position is selected automatically for the image orientation.
+            </p>
+          </div>
+        ) : selectedTemplate?.customDraw === 'gallery-placard' ? (
+          <PositionSelector variant="gallery" />
+        ) : (
+          <PositionSelector />
+        )}
       </div>
     </div>
   );

--- a/src/components/editor/__tests__/TemplateSelector.test.tsx
+++ b/src/components/editor/__tests__/TemplateSelector.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { TemplateSelector } from '../TemplateSelector';
+import {
+  captionTemplate,
+  filmTemplate,
+  galleryPlacardTemplate,
+} from '@/templates';
+import { useSettingsStore } from '@/stores/settingsStore';
+import { useTemplateStore } from '@/stores/templateStore';
+
+describe('TemplateSelector position controls', () => {
+  beforeEach(() => {
+    useTemplateStore.setState({ selectedTemplate: captionTemplate });
+    useSettingsStore.getState().updateCanvasSettings({
+      overlayPosition: 'top-left',
+    });
+  });
+
+  it('explains that Caption has a fixed position', () => {
+    render(<TemplateSelector />);
+    expect(screen.getByText('Caption is fixed below the photo.')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Top Left' })).toBeNull();
+  });
+
+  it('explains that Film position is automatic', () => {
+    useTemplateStore.setState({ selectedTemplate: filmTemplate });
+    render(<TemplateSelector />);
+    expect(
+      screen.getByText(
+        'Film position is selected automatically for the image orientation.'
+      )
+    ).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Top Left' })).toBeNull();
+  });
+
+  it('shows the actual Gallery Placard layouts', () => {
+    useTemplateStore.setState({ selectedTemplate: galleryPlacardTemplate });
+    render(<TemplateSelector />);
+
+    expect(screen.getByRole('group', { name: 'Placard layout' })).toBeTruthy();
+    const split = screen.getByRole('button', { name: 'Split panels' });
+    fireEvent.click(split);
+
+    expect(useSettingsStore.getState().canvasSettings.overlayPosition).toBe(
+      'bottom-right'
+    );
+    expect(split.getAttribute('aria-pressed')).toBe('true');
+  });
+});


### PR DESCRIPTION
What:
Make position controls match the template-specific behavior for caption, film, and gallery layouts.

Why:
The UI exposed the wrong control set for some template modes.

Impact:
Positioning options now reflect the active template more accurately.

Checks:
- TypeScript
- lint
- tests
- build

Notes:
This is mostly UI-local and can merge independently of the rendering fixes.