### PR TITLE
fix: improve pan and zoom interactions

### DIFF
--- a/src/components/workspace/ImageWorkspace.tsx
+++ b/src/components/workspace/ImageWorkspace.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 
 import { useImageUpload } from '@/hooks/useImageUpload';
 import { useCanvasRenderer } from '@/hooks/useCanvasRenderer';
-import { usePanZoom } from '@/hooks/usePanZoom';
+import { MAX_SCALE, usePanZoom } from '@/hooks/usePanZoom';
 import {
   ImageIcon,
   DownloadIcon,
@@ -33,12 +33,13 @@ export function ImageWorkspace() {
 
   // Called unconditionally — before the early return — so hook call order is
   // stable. enabled=false and resetKey=null are safe no-ops inside the hook.
-  const { scale, offset, isPanning, isZoomed, reset, bind } = usePanZoom({
-    viewportRef,
-    contentRef,
-    enabled: !!currentImage,
-    resetKey: currentImage?.id ?? null,
-  });
+  const { scale, offset, isPanning, isZoomed, reset, zoomIn, zoomOut, bind } =
+    usePanZoom({
+      viewportRef,
+      contentRef,
+      enabled: !!currentImage,
+      resetKey: currentImage?.id ?? null,
+    });
 
   const handleClearImage = () => {
     clearImage();
@@ -237,19 +238,38 @@ export function ImageWorkspace() {
           </div>
         )}
 
-        {/* Zoom indicator — visible only when zoomed in */}
-        {isZoomed && (
-          <div
-            data-zoom-ui
-            className="absolute bottom-4 right-4 flex select-none items-center gap-3 rounded-lg border border-white/10 bg-black/75 px-3 py-1.5 font-mono text-xs text-zinc-200 backdrop-blur-sm"
-            onClick={(e) => e.stopPropagation()}
-            // Without this, the viewport's onPointerDown starts a pan and
-            // captures the pointer, which retargets the ensuing click to the
-            // viewport — the Reset button would never receive it.
-            onPointerDown={(e) => e.stopPropagation()}
+        {/* Zoom controls remain available at 1x so touch-only users have an
+            entry point to zoom without relying on a mouse wheel. */}
+        <div
+          data-zoom-ui
+          className="absolute bottom-4 right-4 flex select-none items-center gap-2 rounded-lg border border-white/10 bg-black/75 px-2 py-1.5 font-mono text-xs text-zinc-200 backdrop-blur-sm"
+          onClick={(e) => e.stopPropagation()}
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          <button
+            type="button"
+            aria-label="Zoom out"
+            disabled={!isZoomed}
+            onClick={zoomOut}
+            className="rounded px-1.5 py-0.5 text-base leading-none text-accent transition-colors hover:text-accent/80 disabled:cursor-not-allowed disabled:text-zinc-600"
           >
-            <span>{Math.round(scale * 100)}%</span>
+            −
+          </button>
+          <span className="min-w-10 text-center">
+            {Math.round(scale * 100)}%
+          </span>
+          <button
+            type="button"
+            aria-label="Zoom in"
+            disabled={scale >= MAX_SCALE}
+            onClick={zoomIn}
+            className="rounded px-1.5 py-0.5 text-base leading-none text-accent transition-colors hover:text-accent/80 disabled:cursor-not-allowed disabled:text-zinc-600"
+          >
+            +
+          </button>
+          {isZoomed && (
             <button
+              type="button"
               aria-label="Reset zoom"
               onClick={(e) => {
                 e.stopPropagation();
@@ -259,8 +279,8 @@ export function ImageWorkspace() {
             >
               Reset
             </button>
-          </div>
-        )}
+          )}
+        </div>
       </div>
 
       {/* Floating Controls — always visible: a hover-gated button is

--- a/src/hooks/__tests__/usePanZoom.test.ts
+++ b/src/hooks/__tests__/usePanZoom.test.ts
@@ -205,6 +205,51 @@ describe('usePanZoom hook', () => {
     expect(wheelCalls).toHaveLength(0);
   });
 
+  it('allows page scrolling when the wheel points beyond the 1x boundary', () => {
+    renderHook(() =>
+      usePanZoom({ viewportRef, contentRef, enabled: true, resetKey: null })
+    );
+    const event = new WheelEvent('wheel', {
+      deltaY: 100,
+      cancelable: true,
+      bubbles: true,
+    });
+
+    viewportEl.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  it('captures the wheel only when it can change the zoom', () => {
+    const { result } = renderHook(() =>
+      usePanZoom({ viewportRef, contentRef, enabled: true, resetKey: null })
+    );
+    const event = new WheelEvent('wheel', {
+      deltaY: -100,
+      cancelable: true,
+      bubbles: true,
+    });
+
+    act(() => {
+      viewportEl.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(result.current.scale).toBeGreaterThan(MIN_SCALE);
+  });
+
+  it('provides button-driven zoom for touch-only devices', () => {
+    const { result } = renderHook(() =>
+      usePanZoom({ viewportRef, contentRef, enabled: true, resetKey: null })
+    );
+
+    act(() => result.current.zoomIn());
+    expect(result.current.scale).toBe(1.5);
+
+    act(() => result.current.zoomOut());
+    expect(result.current.scale).toBe(MIN_SCALE);
+  });
+
   it('M-11 regression: mid-pan resetKey change resets isPanning and scale to 1', async () => {
     const { result, rerender } = renderHook(
       ({ enabled, resetKey }: { enabled: boolean; resetKey: string | null }) =>

--- a/src/hooks/usePanZoom.ts
+++ b/src/hooks/usePanZoom.ts
@@ -199,6 +199,15 @@ export function usePanZoom<
     if (!el || !enabled) return;
 
     const handler = (e: WheelEvent) => {
+      const zoomingIn = e.deltaY < 0;
+      const zoomingOut = e.deltaY > 0;
+      if (!zoomingIn && !zoomingOut) return;
+      if (
+        (zoomingIn && state.scale >= MAX_SCALE) ||
+        (zoomingOut && state.scale <= MIN_SCALE)
+      ) {
+        return;
+      }
       e.preventDefault();
       const m = measure();
       if (!m) return;
@@ -216,7 +225,28 @@ export function usePanZoom<
 
     el.addEventListener('wheel', handler, { passive: false });
     return () => el.removeEventListener('wheel', handler);
-  }, [viewportRef, enabled, measure, contentSizeFor]);
+  }, [viewportRef, enabled, measure, contentSizeFor, state.scale]);
+
+  const zoomBy = useCallback(
+    (factor: number) => {
+      if (!enabled) return;
+      const m = measure();
+      if (!m) return;
+      setState((prev) =>
+        zoomAt(
+          prev,
+          { x: 0, y: 0 },
+          prev.scale * factor,
+          m.viewport,
+          contentSizeFor(m, prev.scale)
+        )
+      );
+    },
+    [enabled, measure, contentSizeFor]
+  );
+
+  const zoomIn = useCallback(() => zoomBy(1.5), [zoomBy]);
+  const zoomOut = useCallback(() => zoomBy(1 / 1.5), [zoomBy]);
 
   const onPointerDown = useCallback(
     (e: ReactPointerEvent<HTMLElement>) => {
@@ -287,6 +317,8 @@ export function usePanZoom<
     isPanning,
     isZoomed,
     reset,
+    zoomIn,
+    zoomOut,
     bind: {
       onPointerDown,
       onPointerMove,


### PR DESCRIPTION
What:
Only block wheel scrolling when zoom actually changes, and add always-visible zoom controls for touch-driven flows.

Why:
The old interaction model was too aggressive on wheel input and too dependent on precise pointer gestures.

Impact:
Pan/zoom feels less brittle on desktop and touch devices.

Checks:
- TypeScript
- lint
- tests
- build

Notes:
This is mostly independent, but it touches the same workspace interaction surface as the browser-support work.