### PR TITLE
fix: label editor and export controls

### DIFF
--- a/src/components/editor/LensOverrideField.tsx
+++ b/src/components/editor/LensOverrideField.tsx
@@ -71,7 +71,10 @@ export function LensOverrideField() {
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <h3 className="font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-zinc-500">
+        <h3
+          id="lens-override-label"
+          className="font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-zinc-500"
+        >
           Lens Override
         </h3>
         <span
@@ -90,6 +93,7 @@ export function LensOverrideField() {
 
       <input
         type="text"
+        aria-labelledby="lens-override-label"
         value={inputValue}
         onChange={(e) => setInputValue(e.target.value)}
         disabled={disabled}

--- a/src/components/editor/LocationOverrideField.tsx
+++ b/src/components/editor/LocationOverrideField.tsx
@@ -81,7 +81,10 @@ export function LocationOverrideField() {
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <h3 className="font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-zinc-500">
+        <h3
+          id="location-override-label"
+          className="font-mono text-[11px] font-medium uppercase tracking-[0.18em] text-zinc-500"
+        >
           Location
         </h3>
         <span
@@ -100,6 +103,7 @@ export function LocationOverrideField() {
 
       <input
         type="text"
+        aria-labelledby="location-override-label"
         value={inputValue}
         onChange={(e) => setInputValue(e.target.value)}
         disabled={disabled}

--- a/src/components/editor/__tests__/formAccessibility.test.tsx
+++ b/src/components/editor/__tests__/formAccessibility.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { LensOverrideField } from '../LensOverrideField';
+import { LocationOverrideField } from '../LocationOverrideField';
+import { ExportControls } from '@/components/export/ExportControls';
+import { useSettingsStore } from '@/stores/settingsStore';
+
+describe('editor form accessibility', () => {
+  beforeEach(() => {
+    useSettingsStore.getState().updateCanvasSettings({ format: 'png' });
+  });
+
+  it('gives override inputs accessible names', () => {
+    render(
+      <>
+        <LensOverrideField />
+        <LocationOverrideField />
+      </>
+    );
+
+    expect(screen.getByRole('textbox', { name: 'Lens Override' })).toBeTruthy();
+    expect(screen.getByRole('textbox', { name: 'Location' })).toBeTruthy();
+  });
+
+  it('exposes the selected export format', () => {
+    render(<ExportControls />);
+    const png = screen.getByRole('button', { name: 'png' });
+    const jpeg = screen.getByRole('button', { name: 'jpeg' });
+
+    expect(png.getAttribute('aria-pressed')).toBe('true');
+    expect(jpeg.getAttribute('aria-pressed')).toBe('false');
+
+    fireEvent.click(jpeg);
+
+    expect(png.getAttribute('aria-pressed')).toBe('false');
+    expect(jpeg.getAttribute('aria-pressed')).toBe('true');
+  });
+});

--- a/src/components/export/ExportControls.tsx
+++ b/src/components/export/ExportControls.tsx
@@ -41,6 +41,7 @@ export function ExportControls() {
             <button
               key={format}
               onClick={() => updateCanvasSettings({ format })}
+              aria-pressed={canvasSettings.format === format}
               className={clsx(
                 'rounded-md px-4 py-1.5 font-mono text-xs font-medium uppercase tracking-wider transition-colors',
                 canvasSettings.format === format


### PR DESCRIPTION
What:
Add explicit labels and pressed-state semantics to the editor and export controls.

Why:
Some controls lacked accessible names or state that assistive tech can reliably announce.

Impact:
Keyboard and screen-reader usability improves without changing the visual layout.

Checks:
- TypeScript
- lint
- tests
- build

Notes:
This is independent from the rendering and upload branches.