### PR TITLE
fix: use a valid HEIC header in the decode-failure test

### DIFF
--- a/src/services/__tests__/imageProcessor.test.ts
+++ b/src/services/__tests__/imageProcessor.test.ts
@@ -1,6 +1,20 @@
 import { describe, it, expect, vi } from 'vitest';
 import { ImageProcessor } from '../imageProcessor';
 
+function fileFromBytes(bytes: Uint8Array<ArrayBuffer>, type: string): File {
+  return new File([bytes], 'image', { type });
+}
+
+function heicFile(width: number, height: number): File {
+  const bytes = new Uint8Array(24);
+  const view = new DataView(bytes.buffer);
+  view.setUint32(0, 24);
+  bytes.set([0x69, 0x73, 0x70, 0x65], 4);
+  view.setUint32(12, width);
+  view.setUint32(16, height);
+  return fileFromBytes(bytes, 'image/heic');
+}
+
 describe('ImageProcessor.validateImageFile', () => {
   function createMockFile(type: string, size: number): File {
     const blob = new Blob(['x'.repeat(Math.min(size, 100))], { type });
@@ -33,7 +47,9 @@ describe('ImageProcessor.validateImageFile', () => {
   });
 
   it('explains the native browser requirement when HEIC decoding fails', async () => {
-    const file = createMockFile('image/heic', 1024);
+    // Needs a valid ispe box so validateImageDimensions passes and the
+    // failure happens at the Image decoding stage.
+    const file = heicFile(100, 100);
     const revokeObjectURL = vi.fn();
 
     class FailingImage {
@@ -88,10 +104,6 @@ describe('ImageProcessor.validateImageFile', () => {
 });
 
 describe('ImageProcessor.validateImageDimensions', () => {
-  function fileFromBytes(bytes: Uint8Array<ArrayBuffer>, type: string): File {
-    return new File([bytes], 'image', { type });
-  }
-
   function pngFile(width: number, height: number): File {
     const bytes = new Uint8Array(24);
     bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
@@ -111,16 +123,6 @@ describe('ImageProcessor.validateImageDimensions', () => {
     view.setUint16(9, width);
     bytes.set([0xff, 0xd9], 19);
     return fileFromBytes(bytes, 'image/jpeg');
-  }
-
-  function heicFile(width: number, height: number): File {
-    const bytes = new Uint8Array(24);
-    const view = new DataView(bytes.buffer);
-    view.setUint32(0, 24);
-    bytes.set([0x69, 0x73, 0x70, 0x65], 4);
-    view.setUint32(12, width);
-    view.setUint32(16, height);
-    return fileFromBytes(bytes, 'image/heic');
   }
 
   it.each([


### PR DESCRIPTION
## 概要

main の CI が `imageProcessor.test.ts` の HEIC デコード失敗テストで落ちている問題の修正です。

## 原因

PR #211 と #212 の意味的コンフリクト（テキストレベルでは衝突せず、main で合流して初めて壊れるパターン）です。

- **#211** が `loadImageFile()` の先頭に `validateImageDimensions()` を追加し、HEIC はバイナリの `ispe` ボックスから寸法を読むようになった
- **#212**（#211 を含まない時点から分岐）が追加した HEIC デコード失敗テストのモックファイルは `'x'` を並べただけのダミーで、`ispe` ボックスを持たない

結果、テストが検証したい `Image` デコード段階に到達する前に `'Unable to read image dimensions.'` で reject され、期待するエラーメッセージと一致せず失敗していました。

## 修正内容

- `validateImageDimensions` 側のテストにあった `heicFile()` ヘルパー（有効な `ispe` ボックス入りの HEIC バイト列を生成）をモジュールスコープに移動
- デコード失敗テストのモックをこのヘルパーで生成し、寸法検証を通過してデコード段階で失敗するように変更

## 確認

- `npm test` — 149 テスト全通過
- `npm run lint` / `npm run format:check` / `npx tsc --noEmit` — 全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)