### PR TITLE
Raise image upload size limit to 50MB with rejection toasts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ CI runs: lint → format:check → tsc --noEmit → test → build.
   - `exifExtractor.ts` — Reads EXIF via exifr and normalizes to display strings (ja-JP locale for dates). Routes Sony bodies through `cameraNameFormatter`.
   - `cameraNameFormatter.ts` — Rewrites Sony ILCE/ILCA/DSC model codes into the marketing α-series names (e.g. `ILCE-7M4` → `α7 IV`).
   - `canvasRenderer.ts` — Canvas drawing with dynamic height calculation, text wrapping, responsive font scaling, 4K support. Dispatches per-template rendering via the template's `customDraw` (`caption`, `technical`, `compact`, `imprint`, `gallery-placard`); the film template auto-rotates for portrait images.
-  - `imageProcessor.ts` — File validation (JPEG/PNG and natively supported HEIC, max 20MB), Blob URL lifecycle.
+  - `imageProcessor.ts` — File validation (JPEG/PNG and natively supported HEIC, max 50MB), Blob URL lifecycle.
 - **`src/stores/`** — Zustand stores. Mostly independent; the one cross-store call is `imageStore` clearing `exifStore` when the image is replaced or removed (prevents stale EXIF leaking across images).
   - `imageStore` / `templateStore` — selected image and template preset.
   - `exifStore` — raw + normalized EXIF, plus per-image `lensOverrides` / `locationOverrides` exposed via `getEffectiveNormalizedData`.

--- a/src/components/workspace/ImageWorkspace.tsx
+++ b/src/components/workspace/ImageWorkspace.tsx
@@ -122,7 +122,7 @@ export function ImageWorkspace() {
             </p>
 
             <p className="font-mono text-xs uppercase tracking-wider text-zinc-600">
-              JPEG · PNG · HEIC (supported browsers) — up to 20 MB
+              JPEG · PNG · HEIC (supported browsers) — up to 50 MB
             </p>
           </div>
 

--- a/src/hooks/__tests__/useImageUpload.test.ts
+++ b/src/hooks/__tests__/useImageUpload.test.ts
@@ -4,13 +4,17 @@ import type { ExifData, NormalizedExifData } from '@/types/exif';
 import type { ImageFile } from '@/types/image';
 
 const mocks = vi.hoisted(() => ({
-  onDrop: null as ((files: File[]) => Promise<void>) | null,
+  onDrop: null as
+    | ((files: File[], rejections?: unknown[]) => Promise<void>)
+    | null,
   extractExifData: vi.fn<(file: File) => Promise<ExifData>>(),
   normalizeExifData: vi.fn<(data: ExifData) => NormalizedExifData>(),
 }));
 
 vi.mock('react-dropzone', () => ({
-  useDropzone: (options: { onDrop: (files: File[]) => Promise<void> }) => {
+  useDropzone: (options: {
+    onDrop: (files: File[], rejections?: unknown[]) => Promise<void>;
+  }) => {
     mocks.onDrop = options.onDrop;
     return {
       getRootProps: () => ({}),
@@ -27,6 +31,7 @@ vi.mock('@/services/exifExtractor', () => ({
 }));
 
 import { useImageUpload } from '../useImageUpload';
+import { useToastStore } from '../useToast';
 import { ImageProcessor } from '@/services/imageProcessor';
 import { useExifStore } from '@/stores/exifStore';
 import { useImageStore } from '@/stores/imageStore';
@@ -66,6 +71,7 @@ describe('useImageUpload', () => {
       lensOverrides: {},
       locationOverrides: {},
     });
+    useToastStore.setState({ toasts: [] });
   });
 
   afterEach(() => {
@@ -102,5 +108,72 @@ describe('useImageUpload', () => {
     expect(useExifStore.getState().exifData).toEqual({});
     expect(useExifStore.getState().normalizedData).toEqual({});
     expect(mocks.normalizeExifData).not.toHaveBeenCalled();
+  });
+
+  it('shows an error toast when dropzone rejects a file for exceeding the size limit', async () => {
+    renderHook(() => useImageUpload());
+    const file = new File(['x'], 'huge.jpg', { type: 'image/jpeg' });
+
+    await act(async () => {
+      await mocks.onDrop?.(
+        [],
+        [{ file, errors: [{ code: 'file-too-large', message: 'too large' }] }]
+      );
+    });
+
+    expect(useToastStore.getState().toasts).toEqual([
+      expect.objectContaining({
+        type: 'error',
+        message: 'File too large. Maximum size is 50MB.',
+      }),
+    ]);
+    expect(useImageStore.getState().currentImage).toBeNull();
+  });
+
+  it('shows an error toast when dropzone rejects a file with an unsupported type', async () => {
+    renderHook(() => useImageUpload());
+    const file = new File(['x'], 'movie.gif', { type: 'image/gif' });
+
+    await act(async () => {
+      await mocks.onDrop?.(
+        [],
+        [{ file, errors: [{ code: 'file-invalid-type', message: 'bad type' }] }]
+      );
+    });
+
+    expect(useToastStore.getState().toasts).toEqual([
+      expect.objectContaining({
+        type: 'error',
+        message: 'Unsupported file type. Please use JPEG, PNG, or HEIC files.',
+      }),
+    ]);
+  });
+
+  it('shows a single deduplicated toast for multiple identical rejections', async () => {
+    renderHook(() => useImageUpload());
+    const makeFile = (name: string) =>
+      new File(['x'], name, { type: 'image/jpeg' });
+
+    await act(async () => {
+      await mocks.onDrop?.(
+        [],
+        [
+          {
+            file: makeFile('a.jpg'),
+            errors: [{ code: 'too-many-files', message: 'too many' }],
+          },
+          {
+            file: makeFile('b.jpg'),
+            errors: [{ code: 'too-many-files', message: 'too many' }],
+          },
+        ]
+      );
+    });
+
+    const { toasts } = useToastStore.getState();
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0]?.message).toBe(
+      'Only one image can be uploaded at a time.'
+    );
   });
 });

--- a/src/hooks/useImageUpload.ts
+++ b/src/hooks/useImageUpload.ts
@@ -1,10 +1,29 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useDropzone } from 'react-dropzone';
+import type { FileRejection } from 'react-dropzone';
 import { useImageStore } from '@/stores/imageStore';
 import { useExifStore } from '@/stores/exifStore';
-import { ImageProcessor } from '@/services/imageProcessor';
+import {
+  ImageProcessor,
+  MAX_IMAGE_FILE_SIZE_BYTES,
+  MAX_IMAGE_FILE_SIZE_MB,
+} from '@/services/imageProcessor';
 import { extractExifData, normalizeExifData } from '@/services/exifExtractor';
 import { useToast } from '@/hooks/useToast';
+
+function getRejectionMessage(rejection: FileRejection): string {
+  const code = rejection.errors[0]?.code;
+  switch (code) {
+    case 'file-too-large':
+      return `File too large. Maximum size is ${MAX_IMAGE_FILE_SIZE_MB}MB.`;
+    case 'file-invalid-type':
+      return 'Unsupported file type. Please use JPEG, PNG, or HEIC files.';
+    case 'too-many-files':
+      return 'Only one image can be uploaded at a time.';
+    default:
+      return 'Invalid file.';
+  }
+}
 
 export function useImageUpload() {
   const currentImage = useImageStore((state) => state.currentImage);
@@ -29,9 +48,16 @@ export function useImageUpload() {
   }, [clearImage]);
 
   const onDrop = useCallback(
-    async (acceptedFiles: File[]) => {
+    async (acceptedFiles: File[], fileRejections: FileRejection[]) => {
       const file = acceptedFiles[0];
-      if (!file) return;
+      if (!file) {
+        for (const message of new Set(
+          fileRejections.map(getRejectionMessage)
+        )) {
+          toast.error(message);
+        }
+        return;
+      }
 
       const validation = ImageProcessor.validateImageFile(file);
 
@@ -92,7 +118,7 @@ export function useImageUpload() {
       'image/heic': ['.heic', '.heif'],
     },
     multiple: false,
-    maxSize: 20 * 1024 * 1024,
+    maxSize: MAX_IMAGE_FILE_SIZE_BYTES,
     noClick: !!currentImage,
   });
 

--- a/src/services/__tests__/imageProcessor.test.ts
+++ b/src/services/__tests__/imageProcessor.test.ts
@@ -86,18 +86,18 @@ describe('ImageProcessor.validateImageFile', () => {
     expect(result.error).toContain('Unsupported file type');
   });
 
-  it('rejects files exceeding 20MB', () => {
-    const file = createMockFile('image/jpeg', 21 * 1024 * 1024);
+  it('rejects files exceeding 50MB', () => {
+    const file = createMockFile('image/jpeg', 51 * 1024 * 1024);
     // Override the size property since Blob creation won't actually allocate that much
-    Object.defineProperty(file, 'size', { value: 21 * 1024 * 1024 });
+    Object.defineProperty(file, 'size', { value: 51 * 1024 * 1024 });
     const result = ImageProcessor.validateImageFile(file);
     expect(result.valid).toBe(false);
     expect(result.error).toContain('File too large');
   });
 
-  it('accepts files at exactly 20MB', () => {
-    const file = createMockFile('image/jpeg', 20 * 1024 * 1024);
-    Object.defineProperty(file, 'size', { value: 20 * 1024 * 1024 });
+  it('accepts files at exactly 50MB', () => {
+    const file = createMockFile('image/jpeg', 50 * 1024 * 1024);
+    Object.defineProperty(file, 'size', { value: 50 * 1024 * 1024 });
     const result = ImageProcessor.validateImageFile(file);
     expect(result.valid).toBe(true);
   });

--- a/src/services/imageProcessor.ts
+++ b/src/services/imageProcessor.ts
@@ -3,6 +3,9 @@ import type { ImageFile } from '@/types/image';
 const MAX_IMAGE_PIXELS = 64_000_000;
 const MAX_IMAGE_DIMENSION = 16_384;
 
+export const MAX_IMAGE_FILE_SIZE_MB = 50;
+export const MAX_IMAGE_FILE_SIZE_BYTES = MAX_IMAGE_FILE_SIZE_MB * 1024 * 1024;
+
 interface ImageDimensions {
   width: number;
   height: number;
@@ -140,7 +143,7 @@ export class ImageProcessor {
   }
 
   static validateImageFile(file: File): { valid: boolean; error?: string } {
-    const maxSize = 20 * 1024 * 1024; // 20MB
+    const maxSize = MAX_IMAGE_FILE_SIZE_BYTES;
     const allowedTypes = [
       'image/jpeg',
       'image/png',
@@ -158,7 +161,7 @@ export class ImageProcessor {
     if (file.size > maxSize) {
       return {
         valid: false,
-        error: 'File too large. Maximum size is 20MB.',
+        error: `File too large. Maximum size is ${MAX_IMAGE_FILE_SIZE_MB}MB.`,
       };
     }
 


### PR DESCRIPTION
## Summary

- Upload size limit raised from 20MB to 50MB. The limit is now defined once as `MAX_IMAGE_FILE_SIZE_MB` / `MAX_IMAGE_FILE_SIZE_BYTES` in `imageProcessor.ts` and shared by validation, the dropzone `maxSize`, error messages, and UI copy (previously duplicated as literals in three places).
- Fixed silent failure when a dropped file is rejected by react-dropzone: oversized/unsupported files landed in `fileRejections` and were discarded without any feedback. The drop handler now maps rejection codes (`file-too-large`, `file-invalid-type`, `too-many-files`) to error toasts, deduplicating repeated messages into one toast.
- Pixel-based guards are unchanged (64MP total, 16384px per side), so memory protection still comes from the dimension limits rather than file size.

## Test plan

- [x] Updated boundary tests in `imageProcessor.test.ts` to 50MB (reject 51MB / accept exactly 50MB)
- [x] Added tests in `useImageUpload.test.ts` for size/type rejection toasts and deduplication of multiple rejections
- [x] `npm run lint`, `npx tsc --noEmit`, `npm run format:check`, `npm test` (152 tests) all pass